### PR TITLE
Align more with fiboa CLI #21 (rework parameters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 This repository provides the codebase for working with the [FTW dataset](https://beta.source.coop/repositories/kerner-lab/fields-of-the-world/description/), including tools for data pre-processing, model training, and evaluation.
 
 ## Table of Contents
+
 - [Fields of The World (FTW) - Baselines Codebase](#fields-of-the-world-ftw---baselines-codebase)
   - [Table of Contents](#table-of-contents)
   - [Folder structure](#folder-structure)
@@ -14,19 +15,20 @@ This repository provides the codebase for working with the [FTW dataset](https:/
     - [Verify PyTorch installation and CUDA availability](#verify-pytorch-installation-and-cuda-availability)
     - [Setup FTW CLI](#setup-ftw-cli)
   - [Dataset setup](#dataset-setup)
-      - [Examples:](#examples)
+    - [Examples](#examples)
   - [Dataset visualization](#dataset-visualization)
   - [Pre-requisites for experimentation](#pre-requisites-for-experimentation)
 - [Experimentation](#experimentation)
   - [Training](#training)
-    - [To train a model from scratch:](#to-train-a-model-from-scratch)
-    - [To resume training from a checkpoint:](#to-resume-training-from-a-checkpoint)
-    - [Visualizing the training process](#visuaizing-training-process)
+    - [Train a model from scratch](#train-a-model-from-scratch)
+    - [Resume training from a checkpoint](#resume-training-from-a-checkpoint)
+    - [Visualizing the training process](#visualizing-the-training-process)
   - [Testing](#testing)
-    - [To test a model:](#to-test-a-model)
+    - [Test a model](#test-a-model)
   - [Parallel experimentation](#parallel-experimentation)
-    - [To run experiments in parallel:](#to-run-experiments-in-parallel)
+    - [Run experiments in parallel](#run-experiments-in-parallel)
   - [Inference](#inference)
+    - [Sample Prediction Output (Austria Patch, Red - Fields)](#sample-prediction-output-austria-patch-red---fields)
     - [CC-BY(or equivalent) trained models](#cc-byor-equivalent-trained-models)
   - [Notes](#notes)
   - [Upcoming features](#upcoming-features)
@@ -69,6 +71,7 @@ Fields-of-The-World
 ## System setup
 
 ### Create Conda/Mamba environment
+
 To set up the environment using the provided `env.yml` file:
 
 ```bash
@@ -77,6 +80,7 @@ mamba activate ftw
 ```
 
 ### Verify PyTorch installation and CUDA availability
+
 Verify that PyTorch and CUDA are installed correctly (if using a GPU):
 
 ```bash
@@ -91,7 +95,7 @@ This creates the `ftw` command-line tool, which is used to download and unpack t
 pip install -e .
 ```
 
-```bash
+```
 Usage: ftw [OPTIONS] COMMAND [ARGS]...
 
   Fields of The World (FTW) - Command Line Interface
@@ -109,25 +113,25 @@ Commands:
 
 Download the dataset using the `FTW Cli`, `root_folder` defaults to `./data` and `clean_download` is to freshly download the entire dataset(deletes default local folder):
 
-```bash
+```
 ftw data download --help
 Usage: ftw data download [OPTIONS]
 
   Download the FTW dataset.
 
 Options:
-  --clean_download    If set, the script will delete the root folder before
-                      downloading.
-  --root_folder TEXT  Root folder where the files will be downloaded. Defaults
-                      to './data'.
-  --countries TEXT    Comma-separated list of countries to download. If 'all'
-                      is passed, downloads all available countries.
-  --help              Show this message and exit.
+  -f, --clean_download  If set, the script will delete the root folder before
+                        downloading.
+  --root_folder TEXT    Root folder where the files will be downloaded.
+                        Defaults to './data'.
+  --countries TEXT      Comma-separated list of countries to download. If
+                        'all' is passed, downloads all available countries.
+  --help                Show this message and exit.
 ```
 
 Unpack the dataset using the `unpack.py` script, this will create a `ftw` folder under the `data` after unpacking.
 
-```bash
+```
 ftw data unpack --help
     Usage: ftw data unpack [OPTIONS]
 
@@ -139,7 +143,8 @@ Options:
   --help              Show this message and exit.
 ```
 
-#### Examples:
+### Examples
+
 To download and unpack the complete dataset use following commands:
 
 ```bash
@@ -162,7 +167,6 @@ Explore `visualize_dataset.ipynb` to know more about the dataset.
 
 ![Sample 1](/assets/sample1.png)
 ![Sample 2](/assets/sample2.png)
-
 
 ## Pre-requisites for experimentation
 
@@ -225,7 +229,7 @@ seed_everything: <SEED VALUE>
 
 This section provides guidelines for running model training, testing, and experimentation using multiple GPUs and configuration files.
 
-```bash
+```
 ftw model --help
   Usage: ftw model [OPTIONS] COMMAND [ARGS]...
 
@@ -245,9 +249,9 @@ Commands:
 
 We use [LightningCLI](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.cli.LightningCLI.html) to streamline the training process, leveraging configuration files to define the model architecture, dataset, and training parameters.
 
-### To train a model from scratch:
+### Train a model from scratch
 
-```bash
+```
 ftw model fit --help
 
 Usage: ftw model fit [OPTIONS] [CLI_ARGS]...
@@ -255,8 +259,9 @@ Usage: ftw model fit [OPTIONS] [CLI_ARGS]...
   Fit the model
 
 Options:
-  --config PATH  Path to the config file (required)  [required]
-  --help         Show this message and exit.
+  --config PATH     Path to the config file (required)  [required]
+  --ckpt_path PATH  Path to a checkpoint file to resume training from
+  --help            Show this message and exit.
 ```
 
 You can train your model using a configuration file as follows:
@@ -265,7 +270,7 @@ You can train your model using a configuration file as follows:
 ftw model fit --config configs/example_config.yaml
 ```
 
-### To resume training from a checkpoint:
+### Resume training from a checkpoint
 
 If training has been interrupted or if you wish to fine-tune a pre-trained model, you can resume training from a checkpoint:
 
@@ -301,7 +306,7 @@ Currently logged informations are:
 
 Once your model has been trained, you can evaluate it on the test set specified in your datamodule. This can be done using the same configuration file used for training.
 
-```bash
+```
 ftw model test --help
 
 Usage: ftw model test [OPTIONS] [CLI_ARGS]...
@@ -309,14 +314,14 @@ Usage: ftw model test [OPTIONS] [CLI_ARGS]...
   Test the model
 
 Options:
-  --checkpoint_fn TEXT        Path to model checkpoint  [required]
+  --checkpoint TEXT           Path to model checkpoint  [required]
   --root_dir TEXT             Root directory of dataset
   --gpu INTEGER               GPU to use
   --countries TEXT            Countries to evaluate on  [required]
   --postprocess               Apply postprocessing to the model output
   --iou_threshold FLOAT       IoU threshold for matching predictions to ground
                               truths
-  --output_fn TEXT            Output file for metrics
+ -o, --output TEXT            Output file for metrics
   --model_predicts_3_classes  Whether the model predicts 3 classes or 2
                               classes
   --test_on_3_classes         Whether to test on 3 classes or 2 classes
@@ -326,12 +331,12 @@ Options:
 ```
 
 
-### To test a model:
+### Test a model
 
 Using FTW cli commands to test the model, you can pass specific options, such as selecting the GPUs, providing checkpoints, specifying countries for testing, and postprocessing results:
 
 ```bash
-ftw model test --gpu 0 --root_dir /path/to/dataset --checkpoint_fn logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --output_fn results.csv
+ftw model test --gpu 0 --root_dir /path/to/dataset --checkpoint logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --output results.csv
 ```
 
 This will output test results into `results.csv` after running on the selected GPUs and processing the specified countries.
@@ -342,7 +347,7 @@ Note: If data directory path is custom (not default ./data/) then make sure to p
 
 For running multiple experiments across different GPUs in parallel, the provided Python script `run_experiments.py` can be used. It efficiently manages and distributes training tasks across available GPUs by using multiprocessing and queuing mechanisms.
 
-### To run experiments in parallel:
+### Run experiments in parallel
 
 1. Define the list of experiment configuration files in the `experiment_configs` list.
 2. Specify the list of GPUs in the `GPUS` variable (e.g., `[0,1,2,3]`).
@@ -360,7 +365,7 @@ The script will distribute the experiments across the specified GPUs using a que
 
 We provide the `inference` cli commands to allow users to run models that have been pre-trained on FTW on any temporal pair of S2 images. 
 
-```bash
+```
 ftw inference --help
 
 Usage: ftw inference [OPTIONS] COMMAND [ARGS]...
@@ -388,36 +393,35 @@ Usage: ftw inference download [OPTIONS]
   Download 2 Sentinel-2 scenes & stack them in a single file for inference.
 
 Options:
-  --win_a TEXT      Path to a Sentinel-2 STAC item for the window A image
-                    [required]
-  --win_b TEXT      Path to a Sentinel-2 STAC item for the window B image
-                    [required]
-  --output_fn TEXT  Filename to save results to  [required]
-  --overwrite       Overwrites the outputs if they exist
-  --help            Show this message and exit.
+  --win_a TEXT       Path to a Sentinel-2 STAC item for the window A image
+                     [required]
+  --win_b TEXT       Path to a Sentinel-2 STAC item for the window B image
+                     [required]
+  -o, --output TEXT  Filename to save results to  [required]
+  -f, --overwrite    Overwrites the outputs if they exist
+  --help             Show this message and exit.
 ```
 
 Then `ftw inference run` is the command that will run a given model on overlapping patches of input imagery (i.e. the output of `ftw inference download`) and stitch the results together in GeoTIFF format. 
 
-```bash
-ftw model inference run --help
+```
+ftw inference run --help
 
-Usage: ftw model inference [OPTIONS]
+Usage: ftw inference run [OPTIONS] INPUT
 
-  Run inference on a satellite image
+  Run inference on the stacked Sentinel-2 L2A satellite images specified in
+  INPUT.
 
 Options:
-  --input_fn PATH          Input raster file (Sentinel-2 L2A stack).
-                           [required]
-  --model_fn PATH          Path to the model checkpoint.  [required]
-  --output_fn TEXT         Output filename.  [required]
+  -m, --model PATH         Path to the model checkpoint.  [required]
+  -o, --output TEXT        Output filename.  [required]
   --resize_factor INTEGER  Resize factor to use for inference.
   --gpu INTEGER            GPU ID to use. If not provided, CPU will be used by
                            default.
   --patch_size INTEGER     Size of patch to use for inference.
   --batch_size INTEGER     Batch size.
   --padding INTEGER        Pixels to discard from each side of the patch.
-  --overwrite              Overwrite outputs if they exist.
+  -f, --overwrite          Overwrite outputs if they exist.
   --mps_mode               Run inference in MPS mode (Apple GPUs).
   --help                   Show this message and exit.
 ```
@@ -427,16 +431,15 @@ You can then use the `ftw inference polygonize` command to convert the output of
 ```
 ftw inference polygonize --help
 
-Usage: ftw inference polygonize [OPTIONS]
+Usage: ftw inference polygonize [OPTIONS] INPUT
 
-  Polygonize the output from inference
+  Polygonize the output from inference for the raster image given via INPUT.
 
 Options:
-  --input_fn PATH   Input raster file to polygonize.  [required]
-  --output_fn TEXT  Output filename for the polygonized data.  [required]
-  --simplify FLOAT  Simplification factor to use when polygonizing.
-  --overwrite       Overwrite outputs if they exist.
-  --help            Show this message and exit
+  -o, --output TEXT  Output filename for the polygonized data.  [required]
+  --simplify FLOAT   Simplification factor to use when polygonizing.
+  -f, --overwrite    Overwrite outputs if they exist.
+  --help             Show this message and exit.
 ```
 
 Simplification factor is measured in the units of the coordinate reference system (CRS), and for Sentinel-2 this is meters, so a simplification factor of 15 or 20 is usually sufficient (and recommended, or the vector file will be as large as the raster file).
@@ -455,20 +458,21 @@ The following commands show these four steps for a pair of Sentinel-2 scenes ove
 
 - Download S2 Image scene.
   ```bash
-  ftw inference download --win_a "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210617T100559_R022_T33UUP_20210624T063729" --win_b "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210925T101019_R022_T33UUP_20210926T121923" --output_fn inference_imagery/austria_example.tif
+  ftw inference download --win_a "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210617T100559_R022_T33UUP_20210624T063729" --win_b "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210925T101019_R022_T33UUP_20210926T121923" --output inference_imagery/austria_example.tif
   ```
 
 - Run inference on the entire scene.
   ```bash
-  ftw inference run --input_fn inference_imagery/austria_example.tif --model_fn 3_Class_FULL_FTW_Pretrained.ckpt --output_fn austria_example_output_full.tif --gpu 0 --overwrite --resize_factor 2
+  ftw inference run inference_imagery/austria_example.tif --model 3_Class_FULL_FTW_Pretrained.ckpt --output austria_example_output_full.tif --gpu 0 --overwrite --resize_factor 2
   ```
 
 ### Sample Prediction Output (Austria Patch, Red - Fields)
+
 ![Sample Prediction Output](/assets/austria_prediction.png)
 
 - Polygonize the output.
   ```bash
-  ftw inference polygonize --input_fn austria_example_output_full.tif --output_fn austria_example_output_full.gpkg --simplify 20
+  ftw inference polygonize austria_example_output_full.tif --output austria_example_output_full.gpkg --simplify 20
   ```
 
 ### CC-BY(or equivalent) trained models
@@ -511,7 +515,7 @@ pip install git+https://github.com/Microsoft/torchgeo.git  # to get version 0.7 
 ```python
 from torchgeo.datasets import FieldsOfTheWorld
 ds = FieldsOfTheWorld("dataset/", countries="austria", split="train", download=True)
-````
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ Usage: ftw model fit [OPTIONS] [CLI_ARGS]...
   Fit the model
 
 Options:
-  --config PATH     Path to the config file (required)  [required]
-  --ckpt_path PATH  Path to a checkpoint file to resume training from
-  --help            Show this message and exit.
+  -c, --config PATH  Path to the config file (required)  [required]
+  --ckpt_path PATH   Path to a checkpoint file to resume training from
+  --help             Show this message and exit.
 ```
 
 You can train your model using a configuration file as follows:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Commands:
 
 ## Dataset setup
 
-Download the dataset using the `FTW Cli`, `root_folder` defaults to `./data` and `clean_download` is to freshly download the entire dataset(deletes default local folder):
+Download the dataset using the `FTW Cli`.
+`--out` defaults to `./data` and `--clean_download` is to freshly download the entire dataset (deletes local folder).
 
 ```
 ftw data download --help
@@ -120,27 +121,26 @@ Usage: ftw data download [OPTIONS]
   Download the FTW dataset.
 
 Options:
+  -o, --out TEXT        Folder where the files will be downloaded to. Defaults
+                        to './data'.
   -f, --clean_download  If set, the script will delete the root folder before
                         downloading.
-  --root_folder TEXT    Root folder where the files will be downloaded.
-                        Defaults to './data'.
   --countries TEXT      Comma-separated list of countries to download. If
-                        'all' is passed, downloads all available countries.
+                        'all' (default) is passed, downloads all available
+                        countries.
   --help                Show this message and exit.
 ```
 
-Unpack the dataset using the `unpack.py` script, this will create a `ftw` folder under the `data` after unpacking.
+Unpack the dataset using the `unpack` command, this will create a `ftw` folder under the `data` after unpacking.
 
 ```
-ftw data unpack --help
-    Usage: ftw data unpack [OPTIONS]
+Usage: ftw data unpack [OPTIONS] [INPUT]
 
-  Unpack the downloaded FTW dataset.
+  Unpack the downloaded FTW dataset. Specify the folder where the data is
+  located via INPUT. Defaults to './data'.
 
 Options:
-  --root_folder TEXT  Root folder where the .zip files are located. Defaults
-                      to './data'.
-  --help              Show this message and exit.
+  --help  Show this message and exit.
 ```
 
 ### Examples
@@ -321,7 +321,7 @@ Options:
   --postprocess               Apply postprocessing to the model output
   --iou_threshold FLOAT       IoU threshold for matching predictions to ground
                               truths
- -o, --output TEXT            Output file for metrics
+ -o, --out TEXT               Output file for metrics
   --model_predicts_3_classes  Whether the model predicts 3 classes or 2
                               classes
   --test_on_3_classes         Whether to test on 3 classes or 2 classes
@@ -336,7 +336,7 @@ Options:
 Using FTW cli commands to test the model, you can pass specific options, such as selecting the GPUs, providing checkpoints, specifying countries for testing, and postprocessing results:
 
 ```bash
-ftw model test --gpu 0 --root_dir /path/to/dataset --model logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --output results.csv
+ftw model test --gpu 0 --root_dir /path/to/dataset --model logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --out results.csv
 ```
 
 This will output test results into `results.csv` after running on the selected GPUs and processing the specified countries.
@@ -397,7 +397,7 @@ Options:
                      [required]
   --win_b TEXT       Path to a Sentinel-2 STAC item for the window B image
                      [required]
-  -o, --output TEXT  Filename to save results to  [required]
+  -o, --out TEXT     Filename to save results to  [required]
   -f, --overwrite    Overwrites the outputs if they exist
   --help             Show this message and exit.
 ```
@@ -414,7 +414,7 @@ Usage: ftw inference run [OPTIONS] INPUT
 
 Options:
   -m, --model PATH         Path to the model checkpoint.  [required]
-  -o, --output TEXT        Output filename.  [required]
+  -o, --out TEXT           Output filename.  [required]
   --resize_factor INTEGER  Resize factor to use for inference.
   --gpu INTEGER            GPU ID to use. If not provided, CPU will be used by
                            default.
@@ -436,7 +436,7 @@ Usage: ftw inference polygonize [OPTIONS] INPUT
   Polygonize the output from inference for the raster image given via INPUT.
 
 Options:
-  -o, --output TEXT  Output filename for the polygonized data.  [required]
+  -o, --out TEXT     Output filename for the polygonized data.  [required]
   --simplify FLOAT   Simplification factor to use when polygonizing.
   -f, --overwrite    Overwrite outputs if they exist.
   --help             Show this message and exit.
@@ -458,12 +458,12 @@ The following commands show these four steps for a pair of Sentinel-2 scenes ove
 
 - Download S2 Image scene.
   ```bash
-  ftw inference download --win_a "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210617T100559_R022_T33UUP_20210624T063729" --win_b "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210925T101019_R022_T33UUP_20210926T121923" --output inference_imagery/austria_example.tif
+  ftw inference download --win_a "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210617T100559_R022_T33UUP_20210624T063729" --win_b "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20210925T101019_R022_T33UUP_20210926T121923" --out inference_imagery/austria_example.tif
   ```
 
 - Run inference on the entire scene.
   ```bash
-  ftw inference run inference_imagery/austria_example.tif --model 3_Class_FULL_FTW_Pretrained.ckpt --output austria_example_output_full.tif --gpu 0 --overwrite --resize_factor 2
+  ftw inference run inference_imagery/austria_example.tif --model 3_Class_FULL_FTW_Pretrained.ckpt --out austria_example_output_full.tif --gpu 0 --overwrite --resize_factor 2
   ```
 
 ### Sample Prediction Output (Austria Patch, Red - Fields)
@@ -472,7 +472,7 @@ The following commands show these four steps for a pair of Sentinel-2 scenes ove
 
 - Polygonize the output.
   ```bash
-  ftw inference polygonize austria_example_output_full.tif --output austria_example_output_full.gpkg --simplify 20
+  ftw inference polygonize austria_example_output_full.tif --out austria_example_output_full.gpkg --simplify 20
   ```
 
 ### CC-BY(or equivalent) trained models

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Usage: ftw model test [OPTIONS] [CLI_ARGS]...
   Test the model
 
 Options:
-  --checkpoint TEXT           Path to model checkpoint  [required]
+  -m, --model TEXT            Path to model checkpoint  [required]
   --root_dir TEXT             Root directory of dataset
   --gpu INTEGER               GPU to use
   --countries TEXT            Countries to evaluate on  [required]
@@ -336,7 +336,7 @@ Options:
 Using FTW cli commands to test the model, you can pass specific options, such as selecting the GPUs, providing checkpoints, specifying countries for testing, and postprocessing results:
 
 ```bash
-ftw model test --gpu 0 --root_dir /path/to/dataset --checkpoint logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --output results.csv
+ftw model test --gpu 0 --root_dir /path/to/dataset --model logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --output results.csv
 ```
 
 This will output test results into `results.csv` after running on the selected GPUs and processing the specified countries.

--- a/configs/FTW-25-Experiments-1-1/run_eval.py
+++ b/configs/FTW-25-Experiments-1-1/run_eval.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                     "ftw model test",
                     "--gpu", "0",
                     "--model", checkpoint,
-                    "--output", "results/experiments-1-1.csv",
+                    "--out", "results/experiments-1-1.csv",
                     "--countries", country
                 ]
                 subprocess.call(command)
@@ -65,7 +65,7 @@ if __name__ == "__main__":
                     "ftw model test",
                     "--gpu", "0",
                     "--model", checkpoint,
-                    "--output", "results/experiments-1-1.csv",
+                    "--out", "results/experiments-1-1.csv",
                     "--countries", country,
                     "--model_predicts_3_classes", "True"
                 ]

--- a/configs/FTW-25-Experiments-1-1/run_eval.py
+++ b/configs/FTW-25-Experiments-1-1/run_eval.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
                 command = [
                     "ftw model test",
                     "--gpu", "0",
-                    "--checkpoint_fn", checkpoint,
-                    "--output_fn", "results/experiments-1-1.csv",
+                    "--checkpoint", checkpoint,
+                    "--output", "results/experiments-1-1.csv",
                     "--countries", country
                 ]
                 subprocess.call(command)
@@ -64,8 +64,8 @@ if __name__ == "__main__":
                 command = [
                     "ftw model test",
                     "--gpu", "0",
-                    "--checkpoint_fn", checkpoint,
-                    "--output_fn", "results/experiments-1-1.csv",
+                    "--checkpoint", checkpoint,
+                    "--output", "results/experiments-1-1.csv",
                     "--countries", country,
                     "--model_predicts_3_classes", "True"
                 ]

--- a/configs/FTW-25-Experiments-1-1/run_eval.py
+++ b/configs/FTW-25-Experiments-1-1/run_eval.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
                 command = [
                     "ftw model test",
                     "--gpu", "0",
-                    "--checkpoint", checkpoint,
+                    "--model", checkpoint,
                     "--output", "results/experiments-1-1.csv",
                     "--countries", country
                 ]
@@ -64,7 +64,7 @@ if __name__ == "__main__":
                 command = [
                     "ftw model test",
                     "--gpu", "0",
-                    "--checkpoint", checkpoint,
+                    "--model", checkpoint,
                     "--output", "results/experiments-1-1.csv",
                     "--countries", country,
                     "--model_predicts_3_classes", "True"

--- a/configs/FTW-25-Experiments-1-2/run_eval.py
+++ b/configs/FTW-25-Experiments-1-2/run_eval.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                 "ftw model test",
                 "--gpu", "7",
                 "--model", checkpoint,
-                "--output", "results/experiments-1-2.csv",
+                "--out", "results/experiments-1-2.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True"
             ]

--- a/configs/FTW-25-Experiments-1-2/run_eval.py
+++ b/configs/FTW-25-Experiments-1-2/run_eval.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             command = [
                 "ftw model test",
                 "--gpu", "7",
-                "--checkpoint", checkpoint,
+                "--model", checkpoint,
                 "--output", "results/experiments-1-2.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True"

--- a/configs/FTW-25-Experiments-1-2/run_eval.py
+++ b/configs/FTW-25-Experiments-1-2/run_eval.py
@@ -47,8 +47,8 @@ if __name__ == "__main__":
             command = [
                 "ftw model test",
                 "--gpu", "7",
-                "--checkpoint_fn", checkpoint,
-                "--output_fn", "results/experiments-1-2.csv",
+                "--checkpoint", checkpoint,
+                "--output", "results/experiments-1-2.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True"
             ]

--- a/configs/FTW-25-Experiments-1-3/run_eval.py
+++ b/configs/FTW-25-Experiments-1-3/run_eval.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                 "ftw model test",
                 "--gpu", "0",
                 "--model", checkpoint,
-                "--output", "with_prp_all_results_train_all_contries_3_class.csv",
+                "--out", "with_prp_all_results_train_all_contries_3_class.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True",
                 "--temporal_options", str(temporal_op),

--- a/configs/FTW-25-Experiments-1-3/run_eval.py
+++ b/configs/FTW-25-Experiments-1-3/run_eval.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
             command = [
                 "ftw model test",
                 "--gpu", "0",
-                "--checkpoint_fn", checkpoint,
-                "--output_fn", "with_prp_all_results_train_all_contries_3_class.csv",
+                "--checkpoint", checkpoint,
+                "--output", "with_prp_all_results_train_all_contries_3_class.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True",
                 "--temporal_options", str(temporal_op),

--- a/configs/FTW-25-Experiments-1-3/run_eval.py
+++ b/configs/FTW-25-Experiments-1-3/run_eval.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             command = [
                 "ftw model test",
                 "--gpu", "0",
-                "--checkpoint", checkpoint,
+                "--model", checkpoint,
                 "--output", "with_prp_all_results_train_all_contries_3_class.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True",

--- a/configs/FTW-25-Experiments-2-1/run_eval.py
+++ b/configs/FTW-25-Experiments-2-1/run_eval.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
             command = [
                 "ftw model test",
                 "--gpu", "0",
-                "--checkpoint", checkpoint,
+                "--model", checkpoint,
                 "--output", "results/experiments-2-1.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True"

--- a/configs/FTW-25-Experiments-2-1/run_eval.py
+++ b/configs/FTW-25-Experiments-2-1/run_eval.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
                 "ftw model test",
                 "--gpu", "0",
                 "--model", checkpoint,
-                "--output", "results/experiments-2-1.csv",
+                "--out", "results/experiments-2-1.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True"
             ]

--- a/configs/FTW-25-Experiments-2-1/run_eval.py
+++ b/configs/FTW-25-Experiments-2-1/run_eval.py
@@ -19,8 +19,8 @@ if __name__ == "__main__":
             command = [
                 "ftw model test",
                 "--gpu", "0",
-                "--checkpoint_fn", checkpoint,
-                "--output_fn", "results/experiments-2-1.csv",
+                "--checkpoint", checkpoint,
+                "--output", "results/experiments-2-1.csv",
                 "--countries", country,
                 "--model_predicts_3_classes", "True"
             ]

--- a/configs/FTW-25-Experiments-2-2/run_eval.py
+++ b/configs/FTW-25-Experiments-2-2/run_eval.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
         command = [
             "ftw model test",
             "--gpu", "1",
-            "--checkpoint_fn", checkpoint,
-            "--output_fn", "results/experiments-2-2.csv",
+            "--checkpoint", checkpoint,
+            "--output", "results/experiments-2-2.csv",
             "--countries", "cambodia", "vietnam",
             "--model_predicts_3_classes", "True"
         ]

--- a/configs/FTW-25-Experiments-2-2/run_eval.py
+++ b/configs/FTW-25-Experiments-2-2/run_eval.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
             "ftw model test",
             "--gpu", "1",
             "--model", checkpoint,
-            "--output", "results/experiments-2-2.csv",
+            "--out", "results/experiments-2-2.csv",
             "--countries", "cambodia", "vietnam",
             "--model_predicts_3_classes", "True"
         ]

--- a/configs/FTW-25-Experiments-2-2/run_eval.py
+++ b/configs/FTW-25-Experiments-2-2/run_eval.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         command = [
             "ftw model test",
             "--gpu", "1",
-            "--checkpoint", checkpoint,
+            "--model", checkpoint,
             "--output", "results/experiments-2-2.csv",
             "--countries", "cambodia", "vietnam",
             "--model_predicts_3_classes", "True"

--- a/configs/FTW-Release/run_eval.py
+++ b/configs/FTW-Release/run_eval.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
                     "--gpu", "0",
                     "--root_dir", "data/ftw",
                     "--model", checkpoint,
-                    "--output", "results/experiments-ftw_release-2_classes.csv",
+                    "--out", "results/experiments-ftw_release-2_classes.csv",
                     "--countries", country
                 ]
                 subprocess.call(command)
@@ -67,7 +67,7 @@ if __name__ == "__main__":
                     "--gpu", "0",
                     "--root_dir", "data/ftw",
                     "--model", checkpoint,
-                    "--output", "results/experiments-ftw_release-3_classes.csv",
+                    "--out", "results/experiments-ftw_release-3_classes.csv",
                     "--countries", country,
                     "--model_predicts_3_classes", "True"
                 ]

--- a/configs/FTW-Release/run_eval.py
+++ b/configs/FTW-Release/run_eval.py
@@ -55,8 +55,8 @@ if __name__ == "__main__":
                     "ftw", "model", "test",
                     "--gpu", "0",
                     "--root_dir", "data/ftw",
-                    "--checkpoint_fn", checkpoint,
-                    "--output_fn", "results/experiments-ftw_release-2_classes.csv",
+                    "--checkpoint", checkpoint,
+                    "--output", "results/experiments-ftw_release-2_classes.csv",
                     "--countries", country
                 ]
                 subprocess.call(command)
@@ -66,8 +66,8 @@ if __name__ == "__main__":
                     "ftw", "model", "test",
                     "--gpu", "0",
                     "--root_dir", "data/ftw",
-                    "--checkpoint_fn", checkpoint,
-                    "--output_fn", "results/experiments-ftw_release-3_classes.csv",
+                    "--checkpoint", checkpoint,
+                    "--output", "results/experiments-ftw_release-3_classes.csv",
                     "--countries", country,
                     "--model_predicts_3_classes", "True"
                 ]

--- a/configs/FTW-Release/run_eval.py
+++ b/configs/FTW-Release/run_eval.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                     "ftw", "model", "test",
                     "--gpu", "0",
                     "--root_dir", "data/ftw",
-                    "--checkpoint", checkpoint,
+                    "--model", checkpoint,
                     "--output", "results/experiments-ftw_release-2_classes.csv",
                     "--countries", country
                 ]
@@ -66,7 +66,7 @@ if __name__ == "__main__":
                     "ftw", "model", "test",
                     "--gpu", "0",
                     "--root_dir", "data/ftw",
-                    "--checkpoint", checkpoint,
+                    "--model", checkpoint,
                     "--output", "results/experiments-ftw_release-3_classes.csv",
                     "--countries", country,
                     "--model_predicts_3_classes", "True"

--- a/src/ftw_cli/download.py
+++ b/src/ftw_cli/download.py
@@ -14,7 +14,7 @@ def ftw():
     pass
 
 @click.command(help="Download the FTW dataset.")
-@click.option('--clean_download', is_flag=True, help="If set, the script will delete the root folder before downloading.")
+@click.option('--clean_download', '-f', is_flag=True, help="If set, the script will delete the root folder before downloading.")
 @click.option('--root_folder', type=str, default="./data", help="Root folder where the files will be downloaded. Defaults to './data'.")
 @click.option('--countries', type=str, default="all", help="Comma-separated list of countries to download. If 'all' is passed, downloads all available countries.")
 def download(clean_download, root_folder, countries):

--- a/src/ftw_cli/download.py
+++ b/src/ftw_cli/download.py
@@ -14,22 +14,11 @@ def ftw():
     pass
 
 @click.command(help="Download the FTW dataset.")
+@click.option('--out', '-o', type=str, default="./data", help="Folder where the files will be downloaded to. Defaults to './data'.")
 @click.option('--clean_download', '-f', is_flag=True, help="If set, the script will delete the root folder before downloading.")
-@click.option('--root_folder', type=str, default="./data", help="Root folder where the files will be downloaded. Defaults to './data'.")
-@click.option('--countries', type=str, default="all", help="Comma-separated list of countries to download. If 'all' is passed, downloads all available countries.")
-def download(clean_download, root_folder, countries):
-    # Use the provided root_folder or prompt the user for it
-    if root_folder is None:
-        root_folder = click.prompt(
-            "Please enter the root folder for downloaded files",
-            default=os.path.abspath('./data'),
-            show_default=True
-        )
-    else:
-        root_folder = os.path.abspath(root_folder)
-
-    # Root folder where the files will be downloaded
-    root_folder_path = root_folder
+@click.option('--countries', type=str, default="all", help="Comma-separated list of countries to download. If 'all' (default) is passed, downloads all available countries.")
+def download(clean_download, out, countries):
+    root_folder_path = os.path.abspath(out)
 
     # Ensure the root folder exists
     os.makedirs(root_folder_path, exist_ok=True)

--- a/src/ftw_cli/inference.py
+++ b/src/ftw_cli/inference.py
@@ -36,16 +36,16 @@ def inference():
 @inference.command(name="download", help="Download 2 Sentinel-2 scenes & stack them in a single file for inference.")
 @click.option('--win_a', type=str, required=True, help="Path to a Sentinel-2 STAC item for the window A image")
 @click.option('--win_b', type=str, required=True, help="Path to a Sentinel-2 STAC item for the window B image")
-@click.option('--output_fn', type=str, required=True, help="Filename to save results to")
-@click.option('--overwrite', is_flag=True, help="Overwrites the outputs if they exist")
-def create_input(win_a, win_b, output_fn, overwrite):
+@click.option('--output', '-o', type=str, required=True, help="Filename to save results to")
+@click.option('--overwrite', '-f', is_flag=True, help="Overwrites the outputs if they exist")
+def create_input(win_a, win_b, output, overwrite):
     """Main function for creating input for inference."""
-    if os.path.exists(output_fn) and not overwrite:
-        print("Output file already exists, use --overwrite to overwrite them. Exiting.")
+    if os.path.exists(output) and not overwrite:
+        print("Output file already exists, use -f to overwrite them. Exiting.")
         return
 
     # Ensure that the base directory exists
-    os.makedirs(os.path.dirname(output_fn), exist_ok=True)
+    os.makedirs(os.path.dirname(output), exist_ok=True)
 
     BANDS_OF_INTEREST = ["B04", "B03", "B02", "B08"]
 
@@ -113,33 +113,33 @@ def create_input(win_a, win_b, output_fn, overwrite):
         profile["blockysize"] = 256
         profile["BIGTIFF"] = "YES"
 
-        with rasterio.open(output_fn, "w", **profile) as f:
+        with rasterio.open(output, "w", **profile) as f:
             f.write(data)
         print(f"Finished merging and writing output in {time.time()-tic:0.2f} seconds")
 
-@inference.command(name="run", help="Run inference on the stacked satellite images")
-@click.option('--input_fn', type=click.Path(exists=True), required=True, help="Input raster file (Sentinel-2 L2A stack).")
-@click.option('--model_fn', type=click.Path(exists=True), required=True, help="Path to the model checkpoint.")
-@click.option('--output_fn', type=str, required=True, help="Output filename.")
+@inference.command(name="run", help="Run inference on the stacked Sentinel-2 L2A satellite images specified via INPUT.")
+@click.argument('input', type=click.Path(exists=True), required=True)
+@click.option('--model', '-m', type=click.Path(exists=True), required=True, help="Path to the model checkpoint.")
+@click.option('--output', '-o', type=str, required=True, help="Output filename.")
 @click.option('--resize_factor', type=int, default=2, help="Resize factor to use for inference.")
 @click.option('--gpu', type=int, help="GPU ID to use. If not provided, CPU will be used by default.")
 @click.option('--patch_size', type=int, default=1024, help="Size of patch to use for inference.")
 @click.option('--batch_size', type=int, default=2, help="Batch size.")
 @click.option('--padding', type=int, default=64, help="Pixels to discard from each side of the patch.")
-@click.option('--overwrite', is_flag=True, help="Overwrite outputs if they exist.")
+@click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
 @click.option('--mps_mode', is_flag=True, help="Run inference in MPS mode (Apple GPUs).")
-def run(input_fn, model_fn, output_fn, resize_factor, gpu, patch_size, batch_size, padding, overwrite, mps_mode):
+def run(input, model, output, resize_factor, gpu, patch_size, batch_size, padding, overwrite, mps_mode):
     # Sanity checks
-    assert os.path.exists(model_fn), f"Model file {model_fn} does not exist."
-    assert model_fn.endswith(".ckpt"), "Model file must be a .ckpt file."
-    assert os.path.exists(input_fn), f"Input file {input_fn} does not exist."
-    assert input_fn.endswith(".tif") or input_fn.endswith(".vrt"), "Input file must be a .tif or .vrt file."
+    assert os.path.exists(model), f"Model file {model} does not exist."
+    assert model.endswith(".ckpt"), "Model file must be a .ckpt file."
+    assert os.path.exists(input), f"Input file {input} does not exist."
+    assert input.endswith(".tif") or input.endswith(".vrt"), "Input file must be a .tif or .vrt file."
     assert int(math.log(patch_size, 2)) == math.log(patch_size, 2), "Patch size must be a power of 2."
 
     stride = patch_size - padding * 2
 
-    if os.path.exists(output_fn) and not overwrite:
-        print(f"Output file {output_fn} already exists. Use --overwrite to overwrite.")
+    if os.path.exists(output) and not overwrite:
+        print(f"Output file {output} already exists. Use -f to overwrite.")
         return
 
     # Determine the device: GPU, MPS, or CPU
@@ -154,7 +154,7 @@ def run(input_fn, model_fn, output_fn, resize_factor, gpu, patch_size, batch_siz
 
     # Load task and data
     tic = time.time()
-    task = CustomSemanticSegmentationTask.load_from_checkpoint(model_fn, map_location="cpu")
+    task = CustomSemanticSegmentationTask.load_from_checkpoint(model, map_location="cpu")
     task.freeze()
     model = task.model.eval().to(device)
 
@@ -165,12 +165,12 @@ def run(input_fn, model_fn, output_fn, resize_factor, gpu, patch_size, batch_siz
         up_sample = K.Resize((patch_size * resize_factor, patch_size * resize_factor)).to(device)
         down_sample = K.Resize((patch_size, patch_size), resample=Resample.NEAREST.name).to(device)
 
-    dataset = SingleRasterDataset(input_fn, transforms=preprocess)
+    dataset = SingleRasterDataset(input, transforms=preprocess)
     sampler = GridGeoSampler(dataset, size=patch_size, stride=stride)
     dataloader = DataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=6, collate_fn=stack_samples)
 
     # Run inference
-    with rasterio.open(input_fn) as f:
+    with rasterio.open(input) as f:
         input_height, input_width = f.shape
         profile = f.profile
         transform = profile["transform"]
@@ -211,38 +211,38 @@ def run(input_fn, model_fn, output_fn, resize_factor, gpu, patch_size, batch_siz
         "interleave": "pixel"
     })
 
-    with rasterio.open(output_fn, "w", **profile) as f:
+    with rasterio.open(output, "w", **profile) as f:
         f.write(output, 1)
         f.write_colormap(1, {1: (255, 0, 0)})
         f.colorinterp = [ColorInterp.palette]
 
-    print(f"Finished inference and saved output to {output_fn} in {time.time() - tic:.2f}s")
+    print(f"Finished inference and saved output to {output} in {time.time() - tic:.2f}s")
 
-@inference.command(name="polygonize", help="Polygonize the output from inference")
-@click.option('--input_fn', type=click.Path(exists=True), required=True, help="Input raster file to polygonize.")
-@click.option('--output_fn', type=str, required=True, help="Output filename for the polygonized data.")
+@inference.command(name="polygonize", help="Polygonize the output from inference for the raster image given via INPUT.")
+@click.argument('input', type=click.Path(exists=True), required=True)
+@click.option('--output', '-o', type=str, required=True, help="Output filename for the polygonized data.")
 @click.option('--simplify', type=float, default=None, help="Simplification factor to use when polygonizing.")
-@click.option('--overwrite', is_flag=True, help="Overwrite outputs if they exist.")
-def polygonize(input_fn, output_fn, simplify, overwrite):
+@click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
+def polygonize(input, output, simplify, overwrite):
     """Polygonize the output from inference."""
 
-    print(f"Polygonizing input file: {input_fn}")
+    print(f"Polygonizing input file: {input}")
 
     # TODO: Get this warning working right, based on the CRS of the input file
     # if simplify is not None and simplify > 1:
     #    print("WARNING: You are passing a value of `simplify` greater than 1 for a geographic coordinate system. This is probably **not** what you want.")
 
-    if os.path.exists(output_fn) and not overwrite:
-        print(f"Output file {output_fn} already exists. Use --overwrite to overwrite.")
+    if os.path.exists(output) and not overwrite:
+        print(f"Output file {output} already exists. Use -f to overwrite.")
         return
-    elif os.path.exists(output_fn) and overwrite:
-        os.remove(output_fn)  # GPKGs are sometimes weird about overwriting in-place
+    elif os.path.exists(output) and overwrite:
+        os.remove(output)  # GPKGs are sometimes weird about overwriting in-place
 
     tic = time.time()
     rows = []
     i = 0
     # read the input file as a mask
-    with rasterio.open(input_fn) as src:
+    with rasterio.open(input) as src:
         input_height, input_width = src.shape
         crs = src.crs.to_string()
         profile = src.profile
@@ -277,7 +277,7 @@ def polygonize(input_fn, output_fn, simplify, overwrite):
         "geometry": "Polygon",
         "properties": {"idx": "int"}
     }
-    with fiona.open(output_fn.replace(".tif", ".gpkg"), "w", driver="GPKG", crs=crs, schema=schema) as f:
+    with fiona.open(output.replace(".tif", ".gpkg"), "w", driver="GPKG", crs=crs, schema=schema) as f:
         f.writerecords(rows)
 
-    print(f"Finished polygonizing output at {output_fn} in {time.time() - tic:.2f}s")
+    print(f"Finished polygonizing output at {output} in {time.time() - tic:.2f}s")

--- a/src/ftw_cli/model.py
+++ b/src/ftw_cli/model.py
@@ -87,7 +87,7 @@ def fit(config, ckpt_path, cli_args):
 
 # Define the 'test' command under 'model'
 @click.command(help="Test the model")
-@click.option('--checkpoint', required=True, type=str, help='Path to model checkpoint')
+@click.option('--model', '-m', required=True, type=str, help='Path to model checkpoint')
 @click.option('--root_dir', type=str, default="data/ftw", help='Root directory of dataset')
 @click.option('--gpu', type=int, default=0, help='GPU to use')
 @click.option('--countries', type=str, multiple=True, required=True, help='Countries to evaluate on')

--- a/src/ftw_cli/model.py
+++ b/src/ftw_cli/model.py
@@ -87,18 +87,18 @@ def fit(config, ckpt_path, cli_args):
 
 # Define the 'test' command under 'model'
 @click.command(help="Test the model")
-@click.option('--checkpoint_fn', required=True, type=str, help='Path to model checkpoint')
+@click.option('--checkpoint', required=True, type=str, help='Path to model checkpoint')
 @click.option('--root_dir', type=str, default="data/ftw", help='Root directory of dataset')
 @click.option('--gpu', type=int, default=0, help='GPU to use')
 @click.option('--countries', type=str, multiple=True, required=True, help='Countries to evaluate on')
 @click.option('--postprocess', is_flag=True, help='Apply postprocessing to the model output')
 @click.option('--iou_threshold', type=float, default=0.5, help='IoU threshold for matching predictions to ground truths')
-@click.option('--output_fn', type=str, default="metrics.json", help='Output file for metrics')
+@click.option('--output', '-o', type=str, default="metrics.json", help='Output file for metrics')
 @click.option('--model_predicts_3_classes', is_flag=True, help='Whether the model predicts 3 classes or 2 classes')
 @click.option('--test_on_3_classes', is_flag=True, help='Whether to test on 3 classes or 2 classes')
 @click.option('--temporal_options', type=str, default="stacked", help='Temporal option (stacked, windowA, windowB, etc.)')
 @click.argument('cli_args', nargs=-1, type=click.UNPROCESSED)  # Capture all remaining arguments
-def test(checkpoint_fn, root_dir, gpu, countries, postprocess, iou_threshold, output_fn, model_predicts_3_classes, test_on_3_classes, temporal_options, cli_args):
+def test(checkpoint, root_dir, gpu, countries, postprocess, iou_threshold, output, model_predicts_3_classes, test_on_3_classes, temporal_options, cli_args):
     """Command to test the model."""
     print("Running test command")
 
@@ -110,7 +110,7 @@ def test(checkpoint_fn, root_dir, gpu, countries, postprocess, iou_threshold, ou
 
     print("Loading model")
     tic = time.time()
-    trainer = CustomSemanticSegmentationTask.load_from_checkpoint(checkpoint_fn, map_location="cpu")
+    trainer = CustomSemanticSegmentationTask.load_from_checkpoint(checkpoint, map_location="cpu")
     model = trainer.model.eval().to(device)
     print(f"Model loaded in {time.time() - tic:.2f}s")
 
@@ -198,175 +198,12 @@ def test(checkpoint_fn, root_dir, gpu, countries, postprocess, iou_threshold, ou
     print(f"Object level precision: {object_precision:.4f}")
     print(f"Object level recall: {object_recall:.4f}")
 
-    if output_fn is not None:
-        if not os.path.exists(output_fn):
-            with open(output_fn, "w") as f:
+    if output is not None:
+        if not os.path.exists(output):
+            with open(output, "w") as f:
                 f.write("train_checkpoint,test_countries,pixel_level_iou,pixel_level_precision,pixel_level_recall,object_level_precision,object_level_recall\n")
-        with open(output_fn, "a") as f:
-            f.write(f"{checkpoint_fn},{countries},{pixel_level_iou},{pixel_level_precision},{pixel_level_recall},{object_precision},{object_recall}\n")
-
-
-# Define the 'inference' command under 'model'
-@click.command(help="Run inference on a satellite image")
-@click.option('--input_fn', type=click.Path(exists=True), required=True, help="Input raster file (Sentinel-2 L2A stack).")
-@click.option('--model_fn', type=click.Path(exists=True), required=True, help="Path to the model checkpoint.")
-@click.option('--output_fn', type=str, required=True, help="Output filename.")
-@click.option('--resize_factor', type=int, default=2, help="Resize factor to use for inference.")
-@click.option('--gpu', type=int, help="GPU ID to use. If not provided, CPU will be used by default.")
-@click.option('--patch_size', type=int, default=1024, help="Size of patch to use for inference.")
-@click.option('--batch_size', type=int, default=2, help="Batch size.")
-@click.option('--padding', type=int, default=64, help="Pixels to discard from each side of the patch.")
-@click.option('--overwrite', is_flag=True, help="Overwrite outputs if they exist.")
-@click.option('--polygonize', is_flag=True, help="Additionally polygonize the output (a GPKG file identical to `output_fn` will be created).")
-@click.option('--simplify', type=float, default=None, help="Simplification factor to use when polygonizing.")
-@click.option('--mps_mode', is_flag=True, help="Run inference in MPS mode (Apple GPUs).")
-def inference(input_fn, model_fn, output_fn, resize_factor, gpu, patch_size, batch_size, padding, overwrite, polygonize, simplify, mps_mode):
-    """Main function for the inference command."""
-
-    # Sanity checks
-    assert os.path.exists(model_fn), f"Model file {model_fn} does not exist."
-    assert model_fn.endswith(".ckpt"), "Model file must be a .ckpt file."
-    assert os.path.exists(input_fn), f"Input file {input_fn} does not exist."
-    assert input_fn.endswith(".tif") or input_fn.endswith(".vrt"), "Input file must be a .tif or .vrt file."
-    assert int(math.log(patch_size, 2)) == math.log(patch_size, 2), "Patch size must be a power of 2."
-    assert output_fn.endswith(".tif"), "Output file must be a .tif file."
-
-    stride = patch_size - padding * 2
-
-    if os.path.exists(output_fn) and not overwrite:
-        print(f"Output file {output_fn} already exists. Use --overwrite to overwrite.")
-        return
-
-    # Determine the device: GPU, MPS, or CPU
-    if mps_mode:
-        assert torch.backends.mps.is_available(), "MPS mode is not available."
-        device = torch.device("mps")
-    elif gpu is not None and torch.cuda.is_available():
-        device = torch.device(f"cuda:{gpu}")
-    else:
-        print("Neither GPU nor MPS mode is enabled, defaulting to CPU.")
-        device = torch.device("cpu")
-
-    # Load task and data
-    tic = time.time()
-    task = CustomSemanticSegmentationTask.load_from_checkpoint(model_fn, map_location="cpu")
-    task.freeze()
-    model = task.model.eval().to(device)
-
-    if mps_mode:
-        up_sample = K.Resize((patch_size * resize_factor, patch_size * resize_factor)).to("cpu")
-        down_sample = K.Resize((patch_size, patch_size), resample=Resample.NEAREST.name).to(device).to("cpu")
-    else:
-        up_sample = K.Resize((patch_size * resize_factor, patch_size * resize_factor)).to(device)
-        down_sample = K.Resize((patch_size, patch_size), resample=Resample.NEAREST.name).to(device)
-
-    dataset = SingleRasterDataset(input_fn, transforms=preprocess)
-    sampler = GridGeoSampler(dataset, size=patch_size, stride=stride)
-    dataloader = DataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=6, collate_fn=stack_samples)
-
-    # Run inference
-    with rasterio.open(input_fn) as f:
-        input_height, input_width = f.shape
-        crs = f.crs.to_string()
-        profile = f.profile
-        transform = profile["transform"]
-
-    is_projected = CRS.from_string(crs).is_projected
-    if polygonize and simplify is not None and not is_projected and simplify > 1:
-        print("WARNING: You are passing a value of `simplify` greater than 1 for a geographic coordinate system. This is probably **not** what you want.")
-
-    output = np.zeros((input_height, input_width), dtype=np.uint8)
-    dl_enumerator = tqdm(dataloader)
-
-    for batch in dl_enumerator:
-        images = batch["image"].to(device)
-        images = up_sample(images)
-        bboxes = batch["bbox"]
-
-        with torch.inference_mode():
-            predictions = model(images)
-            predictions = predictions.argmax(axis=1).unsqueeze(0)
-            predictions = down_sample(predictions.float()).int().cpu().numpy()[0]
-
-        for i in range(len(bboxes)):
-            bb = bboxes[i]
-            left, top = ~transform * (bb.minx, bb.maxy)
-            right, bottom = ~transform * (bb.maxx, bb.miny)
-            left, right, top, bottom = int(np.round(left)), int(np.round(right)), int(np.round(top)), int(np.round(bottom))
-            destination_height, destination_width = output[top + padding:bottom - padding, left + padding:right - padding].shape
-
-            inp = predictions[i][padding:padding + destination_height, padding:padding + destination_width]
-            output[top + padding:bottom - padding, left + padding:right - padding] = inp
-
-    # Save predictions
-    profile.update({
-        "driver": "GTiff",
-        "count": 1,
-        "dtype": "uint8",
-        "compress": "lzw",
-        "nodata": 0,
-        "blockxsize": 512,
-        "blockysize": 512,
-        "tiled": True,
-        "interleave": "pixel"
-    })
-
-    with rasterio.open(output_fn, "w", **profile) as f:
-        f.write(output, 1)
-        f.write_colormap(1, {1: (255, 0, 0)})
-        f.colorinterp = [ColorInterp.palette]
-
-    print(f"Finished inference and saved output to {output_fn} in {time.time() - tic:.2f}s")
-
-    if polygonize:
-        print("Polygonizing output")
-        output_gpkg_fn = output_fn.replace(".tif", ".gpkg")
-        if os.path.exists(output_gpkg_fn) and not overwrite:
-            # TODO: move logic up so we don't do a lot of work then find out we don't want to overwrite
-            print(f"Output file {output_gpkg_fn} already exists. Use --overwrite to overwrite.")
-            return
-        elif os.path.exists(output_gpkg_fn) and overwrite:
-            os.remove(output_gpkg_fn)  # GPKGs are sometimes weird about overwriting in-place
-
-        tic = time.time()
-        rows = []
-        i = 0
-        mask = (output==1).astype(np.uint8)
-
-        input_height, input_width = mask.shape
-        polygonization_stride = 2048
-        total_iterations = (input_height // polygonization_stride) * (input_width // polygonization_stride)
-        with tqdm(total=total_iterations, desc="Processing mask windows") as pbar:
-            for y in range(0, input_height, polygonization_stride):
-                for x in range(0, input_width, polygonization_stride):
-                    new_transform = transform * Affine.translation(x, y)
-                    mask_window = mask[y:y+polygonization_stride, x:x+polygonization_stride]
-                    for geom, val in rasterio.features.shapes(mask_window, transform=new_transform):
-                        if val == 1:
-
-                            if simplify is not None:
-                                geom = shapely.geometry.shape(geom)
-                                geom = geom.simplify(simplify)
-                                geom = shapely.geometry.mapping(geom)
-
-                            rows.append({
-                                "geometry": geom,
-                                "properties": {
-                                    "idx": i
-                                }
-                            })
-                            i += 1
-                    pbar.update(1)
-
-        schema = {
-            "geometry": "Polygon",
-            "properties": {"idx": "int"}
-        }
-        with fiona.open(output_fn.replace(".tif", ".gpkg"), "w", driver="GPKG", crs=crs, schema=schema) as f:
-            f.writerecords(rows)
-
-        print(f"Finished polygonizing output in {time.time() - tic:.2f}s")
-
+        with open(output, "a") as f:
+            f.write(f"{checkpoint},{countries},{pixel_level_iou},{pixel_level_precision},{pixel_level_recall},{object_precision},{object_recall}\n")
 
 
 # Add 'fit' and 'test' commands under the 'model' group

--- a/src/ftw_cli/model.py
+++ b/src/ftw_cli/model.py
@@ -46,7 +46,7 @@ def model():
 
 # Define the 'fit' command under 'model'
 @click.command(help="Fit the model")
-@click.option('--config', required=True, type=click.Path(exists=True), help='Path to the config file (required)')
+@click.option('--config', '-c', required=True, type=click.Path(exists=True), help='Path to the config file (required)')
 @click.option('--ckpt_path', type=click.Path(exists=True), help='Path to a checkpoint file to resume training from')
 @click.argument('cli_args', nargs=-1, type=click.UNPROCESSED)  # Capture all remaining arguments
 def fit(config, ckpt_path, cli_args):

--- a/src/ftw_cli/unpack.py
+++ b/src/ftw_cli/unpack.py
@@ -11,13 +11,13 @@ from tqdm import tqdm
 def ftw():
     pass
 
-@click.command(help="Unpack the downloaded FTW dataset.")
-@click.option('--root_folder', type=str, default="./data", help="Root folder where the .zip files are located. Defaults to './data'.")
-def unpack(root_folder):
-    ftw_folder_path = os.path.join(root_folder, 'ftw')
+@click.command(help="Unpack the downloaded FTW dataset. Specify the folder where the data is located via INPUT. Defaults to './data'.")
+@click.argument('input', type=str, default="./data")
+def unpack(input):
+    ftw_folder_path = os.path.join(input, 'ftw')
 
     clean_and_create_ftw_folder(ftw_folder_path)
-    unpack_zip_files(root_folder, ftw_folder_path)
+    unpack_zip_files(input, ftw_folder_path)
 
 def clean_and_create_ftw_folder(ftw_folder_path):
     """


### PR DESCRIPTION
Partially solves #21 (and went beyond it 🙈)

- --input_fn parameters -> argument (the primary input is usually the argument, but we could also do --input and -i if preferred)
- --output_fn parameters -> --out and add -o (align with fiboa CLI as discussed in #21)
- --overwrite / clean_download -> add -f (pretty common to force overrides/cleaning with -f)
- --checkpoint -> --model and add -m (checkpoint and model parameters had the same description, seems more consistent to align)
- --model -> add -m (simplicity)
- --config -> add -c (pretty common abbreviation)
- --root_dir -> --dir (root in this context seems weird)
- --root_folder in download -> --out and -o (it's the output folder, should be consistent)
- --root_folder in unpack -> argument (primary input as argument again)

Also fixes some Markdown/Readme issues.

Also removes some unused code (I think) - see comments below.