### PR TITLE
Add support for torchgeo 0.6 and fix regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "rioxarray",               # For raster data handling
     "scipy",                   # For scientific computing
     "tensorboard",             # For PyTorch logging
-    "torchgeo==0.5.2",         # For geospatial deep learning
+    "torchgeo",                # For geospatial deep learning
     "fiona",                   # For reading/writing vector data
 ]
 


### PR DESCRIPTION
Fixes the issue with torchgeo>=0.6 and inference. The problem here was that "bbox" was renamed to "bounds" in GeoDataset in torchgeo 0.6. The reason that there are no errors when running the original code with 0.6 is that samples returned by GeoDataset through the DataLoader are defaultdicts, making `batch['bbox']` `None`, meaning we just don't iterate over patches and the inference step returns an array of 0s!

Also fixes a regression in where both the output filename and output raster ndarray were both named `out` (from #35).

I've confirmed that running: `ftw inference run --model FTW-25-Experiment-1-1-4_model.ckpt -o india_img_test.tif --gpu 0 -f --resize_factor 2 tmp/india_img.tif` with both `torchgeo==0.5.2` and `torchgeo==0.6.1` results in correct behavior (and identical output files).



