### PR TITLE
Speedy CLI due to lazy imports #40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ inference_imagery/
 src/ftw.egg-info/
 *.ckpt
 *.tif
+.pytest_cache/

--- a/src/ftw_cli/cli.py
+++ b/src/ftw_cli/cli.py
@@ -1,26 +1,118 @@
 import click
 
-from ftw_cli.download import download
-from ftw_cli.inference import inference
-from ftw_cli.model import model
-from ftw_cli.unpack import unpack
-
+# Imports are in the functions below to speed-up CLI startup time
+# Some of the ML related imports (presumable torch) are very slow
+# See https://github.com/fieldsoftheworld/ftw-baselines/issues/40
 
 @click.group()
 def ftw():
     """Fields of The World (FTW) - Command Line Interface"""
     pass
 
+## Data group
+
 @ftw.group()
 def data():
     """Downloading, unpacking, and preparing the FTW dataset."""
     pass
 
-data.add_command(download, "download")
-data.add_command(unpack, "unpack")
+@data.command("download", help="Download the FTW dataset.")
+@click.option('--out', '-o', type=str, default="./data", help="Folder where the files will be downloaded to. Defaults to './data'.")
+@click.option('--clean_download', '-f', is_flag=True, help="If set, the script will delete the root folder before downloading.")
+@click.option('--countries', type=str, default="all", help="Comma-separated list of countries to download. If 'all' (default) is passed, downloads all available countries.")
+def data_download(out, clean_download, countries):
+    from ftw_cli.download import download as fn
+    fn(out, clean_download, countries)
 
-ftw.add_command(model, "model")
-ftw.add_command(inference, "inference")
+@data.command("unpack", help="Unpack the downloaded FTW dataset. Specify the folder where the data is located via INPUT. Defaults to './data'.")
+@click.argument('input', type=str, default="./data")
+def data_unpack(input):
+    from ftw_cli.unpack import unpack as fn
+    fn(input)
+
+data.add_command(data_download)
+data.add_command(data_unpack)
+
+### Model group
+
+@ftw.group()
+def model():
+    """Training and testing FTW models."""
+    pass
+
+@model.command("fit", help="Fit the model")
+@click.option('--config', '-c', required=True, type=click.Path(exists=True), help='Path to the config file (required)')
+@click.option('--ckpt_path', type=click.Path(exists=True), help='Path to a checkpoint file to resume training from')
+@click.argument('cli_args', nargs=-1, type=click.UNPROCESSED)  # Capture all remaining arguments
+def model_fit(config, ckpt_path, cli_args):
+    from ftw_cli.model import fit
+    fit(config, ckpt_path, cli_args)
+
+@model.command("test", help="Test the model")
+@click.option('--model', '-m', required=True, type=str, help='Path to model checkpoint')
+@click.option('--dir', type=str, default="data/ftw", help='Directory of dataset')
+@click.option('--gpu', type=int, default=0, help='GPU to use')
+@click.option('--countries', type=str, multiple=True, required=True, help='Countries to evaluate on')
+@click.option('--postprocess', is_flag=True, help='Apply postprocessing to the model output')
+@click.option('--iou_threshold', type=float, default=0.5, help='IoU threshold for matching predictions to ground truths')
+@click.option('--out', '-o', type=str, default="metrics.json", help='Output file for metrics')
+@click.option('--model_predicts_3_classes', is_flag=True, help='Whether the model predicts 3 classes or 2 classes')
+@click.option('--test_on_3_classes', is_flag=True, help='Whether to test on 3 classes or 2 classes')
+@click.option('--temporal_options', type=str, default="stacked", help='Temporal option (stacked, windowA, windowB, etc.)')
+@click.argument('cli_args', nargs=-1, type=click.UNPROCESSED)  # Capture all remaining arguments
+def model_test(model, dir, gpu, countries, postprocess, iou_threshold, out, model_predicts_3_classes, test_on_3_classes, temporal_options, cli_args):
+    from ftw_cli.model import test
+    test(model, dir, gpu, countries, postprocess, iou_threshold, out, model_predicts_3_classes, test_on_3_classes, temporal_options, cli_args)
+
+model.add_command(model_fit)
+model.add_command(model_test)
+
+### Inference group
+
+WIN_HELP = "URL to or Microsoft Planetary Computer ID of an Sentinel-2 L2A STAC item for the window {x} image"
+
+@ftw.group()
+def inference():
+    """Inference-related commands."""
+    pass
+
+@inference.command("download", help="Download 2 Sentinel-2 scenes & stack them in a single file for inference.")
+@click.option('--win_a', type=str, required=True, help=WIN_HELP.format(x="A"))
+@click.option('--win_b', type=str, required=True, help=WIN_HELP.format(x="B"))
+@click.option('--out', '-o', type=str, required=True, help="Filename to save results to")
+@click.option('--overwrite', '-f', is_flag=True, help="Overwrites the outputs if they exist")
+def inference_download(win_a, win_b, out, overwrite):
+    from ftw_cli.inference import create_input
+    create_input(win_a, win_b, out, overwrite)
+
+@inference.command("run", help="Run inference on the stacked Sentinel-2 L2A satellite images specified via INPUT.")
+@click.argument('input', type=click.Path(exists=True), required=True)
+@click.option('--model', '-m', type=click.Path(exists=True), required=True, help="Path to the model checkpoint.")
+@click.option('--out', '-o', type=str, required=True, help="Output filename.")
+@click.option('--resize_factor', type=int, default=2, help="Resize factor to use for inference.")
+@click.option('--gpu', type=int, help="GPU ID to use. If not provided, CPU will be used by default.")
+@click.option('--patch_size', type=int, default=1024, help="Size of patch to use for inference.")
+@click.option('--batch_size', type=int, default=2, help="Batch size.")
+@click.option('--padding', type=int, default=64, help="Pixels to discard from each side of the patch.")
+@click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
+@click.option('--mps_mode', is_flag=True, help="Run inference in MPS mode (Apple GPUs).")
+def inference_run(input, model, out, resize_factor, gpu, patch_size, batch_size, padding, overwrite, mps_mode):
+    from ftw_cli.inference import run
+    run(input, model, out, resize_factor, gpu, patch_size, batch_size, padding, overwrite, mps_mode)
+
+@inference.command("polygonize", help="Polygonize the output from inference for the raster image given via INPUT.")
+@click.argument('input', type=click.Path(exists=True), required=True)
+@click.option('--out', '-o', type=str, required=True, help="Output filename for the polygonized data.")
+@click.option('--simplify', type=float, default=None, help="Simplification factor to use when polygonizing.")
+@click.option('--min_size', type=float, default=500, help="Minimum area size in square meters to include in the output.")
+@click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
+def inference_polygonize(input, out, simplify, min_size, overwrite):
+    from ftw_cli.inference import polygonize
+    polygonize(input, out, simplify, min_size, overwrite)
+
+inference.add_command(inference_download)
+inference.add_command(inference_polygonize)
+inference.add_command(inference_run)
 
 if __name__ == "__main__":
     ftw()

--- a/src/ftw_cli/download.py
+++ b/src/ftw_cli/download.py
@@ -4,19 +4,9 @@ import os
 import shutil
 import time
 
-import click
 import wget
 from tqdm import tqdm
 
-
-@click.group()
-def ftw():
-    pass
-
-@click.command(help="Download the FTW dataset.")
-@click.option('--out', '-o', type=str, default="./data", help="Folder where the files will be downloaded to. Defaults to './data'.")
-@click.option('--clean_download', '-f', is_flag=True, help="If set, the script will delete the root folder before downloading.")
-@click.option('--countries', type=str, default="all", help="Comma-separated list of countries to download. If 'all' (default) is passed, downloads all available countries.")
 def download(out, clean_download, countries):
     root_folder_path = os.path.abspath(out)
 
@@ -223,9 +213,3 @@ def download(out, clean_download, countries):
 
     else:
         print("Failed to download checksum.md5 file.")
-
-# Add the download command to the ftw click group
-ftw.add_command(download)
-
-if __name__ == "__main__":
-    ftw()

--- a/src/ftw_cli/inference.py
+++ b/src/ftw_cli/inference.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 import time
 
-import click
 import fiona
 import fiona.transform
 import kornia.augmentation as K
@@ -13,7 +12,7 @@ import planetary_computer as pc
 import pystac
 import rasterio
 import rasterio.features
-import rioxarray # seems unused but is needed
+import rioxarray  # seems unused but is needed
 import shapely.geometry
 import torch
 from affine import Affine
@@ -27,14 +26,8 @@ from ftw.datamodules import preprocess
 from ftw.datasets import SingleRasterDataset
 from ftw.trainers import CustomSemanticSegmentationTask
 
-
 MSPC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
 COLLECTION_ID = "sentinel-2-l2a"
-
-@click.group()
-def inference():
-    """Inference-related commands."""
-    pass
 
 def get_item(id):
     if "/" not in id:
@@ -49,13 +42,7 @@ def get_item(id):
 
     return item
 
-WIN_HELP = "URL to or Microsoft Planetary Computer ID of an Sentinel-2 L2A STAC item for the window {x} image"
 
-@inference.command(name="download", help="Download 2 Sentinel-2 scenes & stack them in a single file for inference.")
-@click.option('--win_a', type=str, required=True, help=WIN_HELP.format(x="A"))
-@click.option('--win_b', type=str, required=True, help=WIN_HELP.format(x="B"))
-@click.option('--out', '-o', type=str, required=True, help="Filename to save results to")
-@click.option('--overwrite', '-f', is_flag=True, help="Overwrites the outputs if they exist")
 def create_input(win_a, win_b, out, overwrite):
     """Main function for creating input for inference."""
     if os.path.exists(out) and not overwrite:
@@ -135,17 +122,7 @@ def create_input(win_a, win_b, out, overwrite):
             f.write(data)
         print(f"Finished merging and writing output in {time.time()-tic:0.2f} seconds")
 
-@inference.command(name="run", help="Run inference on the stacked Sentinel-2 L2A satellite images specified via INPUT.")
-@click.argument('input', type=click.Path(exists=True), required=True)
-@click.option('--model', '-m', type=click.Path(exists=True), required=True, help="Path to the model checkpoint.")
-@click.option('--out', '-o', type=str, required=True, help="Output filename.")
-@click.option('--resize_factor', type=int, default=2, help="Resize factor to use for inference.")
-@click.option('--gpu', type=int, help="GPU ID to use. If not provided, CPU will be used by default.")
-@click.option('--patch_size', type=int, default=1024, help="Size of patch to use for inference.")
-@click.option('--batch_size', type=int, default=2, help="Batch size.")
-@click.option('--padding', type=int, default=64, help="Pixels to discard from each side of the patch.")
-@click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
-@click.option('--mps_mode', is_flag=True, help="Run inference in MPS mode (Apple GPUs).")
+
 def run(input, model, out, resize_factor, gpu, patch_size, batch_size, padding, overwrite, mps_mode):
     # Sanity checks
     assert os.path.exists(model), f"Model file {model} does not exist."
@@ -239,12 +216,7 @@ def run(input, model, out, resize_factor, gpu, patch_size, batch_size, padding, 
 
     print(f"Finished inference and saved output to {out} in {time.time() - tic:.2f}s")
 
-@inference.command(name="polygonize", help="Polygonize the output from inference for the raster image given via INPUT.")
-@click.argument('input', type=click.Path(exists=True), required=True)
-@click.option('--out', '-o', type=str, required=True, help="Output filename for the polygonized data.")
-@click.option('--simplify', type=float, default=None, help="Simplification factor to use when polygonizing.")
-@click.option('--min_size', type=float, default=500, help="Minimum area size in square meters to include in the output.")
-@click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
+
 def polygonize(input, out, simplify, min_size, overwrite):
     """Polygonize the output from inference."""
 

--- a/src/ftw_cli/model.py
+++ b/src/ftw_cli/model.py
@@ -1,11 +1,9 @@
 import os
 import time
 
-import click
 import numpy as np
 import torch
 from lightning.pytorch.cli import LightningCLI
-from pyproj import CRS
 from torch.utils.data import DataLoader
 from torchgeo.datamodules import BaseDataModule
 from torchgeo.trainers import BaseTask
@@ -18,25 +16,6 @@ from ftw.metrics import get_object_level_metrics
 from ftw.trainers import CustomSemanticSegmentationTask
 
 
-# Define the main click group
-@click.group()
-def ftw():
-    """CLI group for FTW commands."""
-    pass
-
-
-# Define the 'model' click group
-@click.group()
-def model():
-    """Training and testing FTW models."""
-    pass
-
-
-# Define the 'fit' command under 'model'
-@click.command(help="Fit the model")
-@click.option('--config', '-c', required=True, type=click.Path(exists=True), help='Path to the config file (required)')
-@click.option('--ckpt_path', type=click.Path(exists=True), help='Path to a checkpoint file to resume training from')
-@click.argument('cli_args', nargs=-1, type=click.UNPROCESSED)  # Capture all remaining arguments
 def fit(config, ckpt_path, cli_args):
     """Command to fit the model."""
     print("Running fit command")
@@ -72,20 +51,6 @@ def fit(config, ckpt_path, cli_args):
     )
 
 
-
-# Define the 'test' command under 'model'
-@click.command(help="Test the model")
-@click.option('--model', '-m', required=True, type=str, help='Path to model checkpoint')
-@click.option('--dir', type=str, default="data/ftw", help='Directory of dataset')
-@click.option('--gpu', type=int, default=0, help='GPU to use')
-@click.option('--countries', type=str, multiple=True, required=True, help='Countries to evaluate on')
-@click.option('--postprocess', is_flag=True, help='Apply postprocessing to the model output')
-@click.option('--iou_threshold', type=float, default=0.5, help='IoU threshold for matching predictions to ground truths')
-@click.option('--out', '-o', type=str, default="metrics.json", help='Output file for metrics')
-@click.option('--model_predicts_3_classes', is_flag=True, help='Whether the model predicts 3 classes or 2 classes')
-@click.option('--test_on_3_classes', is_flag=True, help='Whether to test on 3 classes or 2 classes')
-@click.option('--temporal_options', type=str, default="stacked", help='Temporal option (stacked, windowA, windowB, etc.)')
-@click.argument('cli_args', nargs=-1, type=click.UNPROCESSED)  # Capture all remaining arguments
 def test(model, dir, gpu, countries, postprocess, iou_threshold, out, model_predicts_3_classes, test_on_3_classes, temporal_options, cli_args):
     """Command to test the model."""
     print("Running test command")
@@ -192,15 +157,3 @@ def test(model, dir, gpu, countries, postprocess, iou_threshold, out, model_pred
                 f.write("train_checkpoint,test_countries,pixel_level_iou,pixel_level_precision,pixel_level_recall,object_level_precision,object_level_recall\n")
         with open(out, "a") as f:
             f.write(f"{model},{countries},{pixel_level_iou},{pixel_level_precision},{pixel_level_recall},{object_precision},{object_recall}\n")
-
-
-# Add 'fit' and 'test' commands under the 'model' group
-model.add_command(fit)
-model.add_command(test)
-
-# Add the 'model' group under the 'ftw' group
-ftw.add_command(model)
-
-
-if __name__ == "__main__":
-    ftw()

--- a/src/ftw_cli/unpack.py
+++ b/src/ftw_cli/unpack.py
@@ -4,16 +4,8 @@ import shutil
 import sys
 import zipfile
 
-import click
 from tqdm import tqdm
 
-
-@click.group()
-def ftw():
-    pass
-
-@click.command(help="Unpack the downloaded FTW dataset. Specify the folder where the data is located via INPUT. Defaults to './data'.")
-@click.argument('input', type=str, default="./data")
 def unpack(input):
     ftw_folder_path = os.path.join(input, 'ftw')
 
@@ -86,6 +78,3 @@ def unpack_zip_files(root_folder_path, ftw_folder_path):
     with multiprocessing.Pool(cpu_count) as pool:
         for _ in tqdm(pool.starmap(unpack_zip_file, tasks), total=len(tasks), desc="Unpacking files"):
             pass
-
-if __name__ == "__main__":
-    ftw()

--- a/src/tests/test_data.py
+++ b/src/tests/test_data.py
@@ -1,7 +1,9 @@
-from ftw_cli.download import download
-from ftw_cli.unpack import unpack
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
+
+from ftw_cli.cli import data_download as download
+from ftw_cli.cli import data_unpack as unpack
+
 
 @pytest.mark.filterwarnings('ignore::FutureWarning')
 def test_data_download():

--- a/src/tests/test_inference.py
+++ b/src/tests/test_inference.py
@@ -1,13 +1,14 @@
 
-from ftw_cli.inference import create_input, polygonize, run
 from click.testing import CliRunner
-import pytest
+
+from ftw_cli.cli import inference_download, inference_polygonize, inference_run
+
 
 def test_inference_download(): # create_input
     runner = CliRunner()
 
     # Check help
-    result = runner.invoke(create_input, ["--help"])
+    result = runner.invoke(inference_download, ["--help"])
     assert result.exit_code == 0, result.output
     assert "Usage: download [OPTIONS]" in result.output
 
@@ -17,7 +18,7 @@ def test_inference_polygonize():
     runner = CliRunner()
 
     # Check help
-    result = runner.invoke(polygonize, ["--help"])
+    result = runner.invoke(inference_polygonize, ["--help"])
     assert result.exit_code == 0, result.output
     assert "Usage: polygonize [OPTIONS] INPUT" in result.output
 
@@ -27,7 +28,7 @@ def test_inference_run():
     runner = CliRunner()
 
     # Check help
-    result = runner.invoke(run, ["--help"])
+    result = runner.invoke(inference_run, ["--help"])
     assert result.exit_code == 0, result.output
     assert "Usage: run [OPTIONS] INPUT" in result.output
 

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -1,13 +1,14 @@
 
-from ftw_cli.model import fit, test
 from click.testing import CliRunner
-import pytest
+
+from ftw_cli.cli import model_fit, model_test
+
 
 def test_model_fit():
     runner = CliRunner()
 
     # Check help
-    result = runner.invoke(fit, ["--help"])
+    result = runner.invoke(model_fit, ["--help"])
     assert result.exit_code == 0, result.output
     assert "Usage: fit [OPTIONS] [CLI_ARGS]..." in result.output
 
@@ -17,7 +18,7 @@ def test_model_test():
     runner = CliRunner()
 
     # Check help
-    result = runner.invoke(test, ["--help"])
+    result = runner.invoke(model_test, ["--help"])
     assert result.exit_code == 0, result.output
     assert "Usage: test [OPTIONS] [CLI_ARGS]..." in result.output
 


### PR DESCRIPTION
Not loading all functioins of the CLI directly and as such omitting the init work in torch etc.

Speeds up the CLI responsiveness on each CLI command from a couple of seconds to pretty much instantaneously.

Tests ensure that all commands still react accordingly.