### PR TITLE
Polygonize: Write parquet compliant to fiboa with additional metadata #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,10 @@ The following commands show these four steps for a pair of Sentinel-2 scenes ove
 - Polygonize the output.
   
   ```bash
-  ftw inference polygonize austria_example_output_full.tif --out austria_example_output_full.gpkg --simplify 20
+  ftw inference polygonize austria_example_output_full.tif --simplify 20
   ```
+
+This results in a fiboa-compliant file named `austria_example_output_full.parquet`.
 
 ### CC-BY (or equivalent) trained models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "torchgeo",                # For geospatial deep learning
     "fiona",                   # For reading/writing vector data
     "pyproj",                  # For projections and CRSes
+    "fiboa-cli==0.7.0",        # For storing data in Fiboa format
 ]
 
 [project.optional-dependencies]

--- a/src/ftw_cli/cfg.py
+++ b/src/ftw_cli/cfg.py
@@ -4,7 +4,7 @@ COLLECTION_ID = "sentinel-2-l2a"
 BANDS_OF_INTEREST = ["B04", "B03", "B02", "B08"]
 
 # Supported file formats for the inference polygon command
-SUPPORTED_POLY_FORMATS_TXT = "Available file extensions: .fgb (FlatGeoBuf), .gpkg (GeoPackage), .parquet (GeoParquet, see GDAL requirements), .geojson and .json (GeoJSON)"
+SUPPORTED_POLY_FORMATS_TXT = "Available file extensions: .fgb (FlatGeoBuf), .gpkg (GeoPackage), .parquet (GeoParquet, fiboa-compliant), .geojson and .json (GeoJSON)"
 
 # List of all available countries
 ALL_COUNTRIES = [

--- a/src/ftw_cli/cfg.py
+++ b/src/ftw_cli/cfg.py
@@ -4,7 +4,7 @@ COLLECTION_ID = "sentinel-2-l2a"
 BANDS_OF_INTEREST = ["B04", "B03", "B02", "B08"]
 
 # Supported file formats for the inference polygon command
-SUPPORTED_POLY_FORMATS_TXT = "Available file extensions: .fgb (FlatGeoBuf), .gpkg (GeoPackage), .parquet (GeoParquet, fiboa-compliant), .geojson and .json (GeoJSON)"
+SUPPORTED_POLY_FORMATS_TXT = "Available file extensions: .parquet (GeoParquet, fiboa-compliant), .fgb (FlatGeoBuf), .gpkg (GeoPackage), .geojson and .json (GeoJSON)"
 
 # List of all available countries
 ALL_COUNTRIES = [

--- a/src/ftw_cli/cli.py
+++ b/src/ftw_cli/cli.py
@@ -108,7 +108,7 @@ def inference_run(input, model, out, resize_factor, gpu, patch_size, batch_size,
 
 @inference.command("polygonize", help="Polygonize the output from inference for the raster image given via INPUT. Results are in the CRS of the given raster image.")
 @click.argument('input', type=click.Path(exists=True), required=True)
-@click.option('--out', '-o', type=str, required=True, help="Output filename for the polygonized data. " + SUPPORTED_POLY_FORMATS_TXT)
+@click.option('--out', '-o', type=str, default=None, help="Output filename for the polygonized data. If not given defaults to the name of the input file with parquet extension. " + SUPPORTED_POLY_FORMATS_TXT)
 @click.option('--simplify', type=float, default=15, show_default=True, help="Simplification factor to use when polygonizing in the unit of the CRS, e.g. meters for Sentinel-2 imagery in UTM. Set to 0 to disable simplification.")
 @click.option('--min_size', type=float, default=500, show_default=True, help="Minimum area size in square meters to include in the output.")
 @click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")

--- a/src/ftw_cli/download_img.py
+++ b/src/ftw_cli/download_img.py
@@ -39,6 +39,9 @@ def create_input(win_a, win_b, out, overwrite):
     item_win_a = get_item(win_a)
     item_win_b = get_item(win_b)
 
+    timestamps = list(filter(lambda x: x is not None, [item_win_a.datetime, item_win_b.datetime]))
+    timestamp = max(timestamps) if len(timestamps) > 0 else None
+
     # TODO: Check that items are spatially aligned, or implement a way to only download the intersection
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -101,5 +104,8 @@ def create_input(win_a, win_b, out, overwrite):
         profile["BIGTIFF"] = "YES"
 
         with rasterio.open(out, "w", **profile) as f:
+            if timestamp is not None:
+                tiff_tags = {"TIFFTAG_DATETIME": timestamp.strftime("%Y:%m:%d %H:%M:%S")}
+                f.update_tags(**tiff_tags)
             f.write(data)
         print(f"Finished merging and writing output in {time.time()-tic:0.2f} seconds")

--- a/src/ftw_cli/polygonize.py
+++ b/src/ftw_cli/polygonize.py
@@ -26,6 +26,9 @@ def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
     # if simplify is not None and simplify > 1:
     #    print("WARNING: You are passing a value of `simplify` greater than 1 for a geographic coordinate system. This is probably **not** what you want.")
 
+    if not out:
+        out = os.path.splitext(input)[0] + ".parquet"
+
     if os.path.exists(out) and not overwrite:
         print(f"Output file {out} already exists. Use -f to overwrite.")
         return
@@ -136,6 +139,7 @@ def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
         
         create_parquet(gdf, columns, collection, out, config, compression = "brotli")
     else:
+        print("WARNING: The fiboa-compliant GeoParquet output format is recommended for field boundaries.")
         with fiona.open(out, 'w', format, schema=schema, crs=original_crs) as dst:
             dst.writerecords(rows)
 

--- a/src/ftw_cli/polygonize.py
+++ b/src/ftw_cli/polygonize.py
@@ -1,5 +1,6 @@
 import math
 import os
+import re
 import time
 
 import fiona
@@ -9,10 +10,12 @@ import rasterio
 import rasterio.features
 import shapely.geometry
 from affine import Affine
+from fiboa_cli.parquet import create_parquet, features_to_dataframe
 from pyproj import CRS
 from tqdm import tqdm
 
 from .cfg import SUPPORTED_POLY_FORMATS_TXT
+
 
 def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
     """Polygonize the output from inference."""
@@ -31,20 +34,27 @@ def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
 
     tic = time.time()
     rows = []
-    schema = {'geometry': 'Polygon', 'properties': {'id': 'str', 'area': 'float'}}
+    schema = {
+        'geometry': 'Polygon',
+        'properties': {
+            'id': 'str',
+            'area': 'float',
+            'perimeter': 'float',
+        }
+    }
     i = 1
     # read the input file as a mask
     with rasterio.open(input) as src:
-        input_height, input_width = src.shape
         original_crs = src.crs.to_string()
         is_meters = src.crs.linear_units in ["m", "metre", "meter"]
-        transform = src.transform 
+        transform = src.transform
+        equal_area_crs = CRS.from_epsg(6933) # Define the equal-area projection using EPSG:6933
+        tags = src.tags()
+
+        input_height, input_width = src.shape
         mask = (src.read(1) == 1).astype(np.uint8)
         polygonization_stride = 2048
         total_iterations = math.ceil(input_height / polygonization_stride) * math.ceil(input_width / polygonization_stride)
-        
-        # Define the equal-area projection using EPSG:6933
-        equal_area_crs = CRS.from_epsg(6933)
 
         if out.endswith(".gpkg"):
             format = "GPKG"
@@ -57,15 +67,12 @@ def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
         else:
             raise ValueError("Output format not supported. " + SUPPORTED_POLY_FORMATS_TXT)
 
-        with (
-            fiona.open(out, 'w', format, schema=schema, crs=original_crs) as dst,
-            tqdm(total=total_iterations, desc="Processing mask windows") as pbar
-        ):
+        rows = []
+        with tqdm(total=total_iterations, desc="Processing mask windows") as pbar:
             for y in range(0, input_height, polygonization_stride):
                 for x in range(0, input_width, polygonization_stride):
                     new_transform = transform * Affine.translation(x, y)
                     mask_window = mask[y:y+polygonization_stride, x:x+polygonization_stride]
-                    rows = []
                     for geom_geojson, val in rasterio.features.shapes(mask_window, transform=new_transform):
                         if val != 1:
                             continue
@@ -79,32 +86,57 @@ def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
                         
                         # Calculate the area of the reprojected geometry
                         if is_meters:
-                            area = geom.area
+                            geom_proj_meters = geom
                         else:
                             # Reproject the geometry to the equal-area projection
                             # if the CRS is not in meters
-                            geom_area_proj = fiona.transform.transform_geom(
-                                original_crs, equal_area_crs, geom_geojson
+                            geom_proj_meters = shapely.geometry.shape(
+                                fiona.transform.transform_geom(
+                                    original_crs, equal_area_crs, geom_geojson
+                                )
                             )
-                            area = shapely.geometry.shape(geom_area_proj).area  
+
+                        area = geom_proj_meters.area
+                        perimeter = geom_proj_meters.length
                         
                         # Only include geometries that meet the minimum size requirement
                         if area < min_size:
                             continue
 
-                        # Keep the geometry in the original projection for output
-                        geom = shapely.geometry.mapping(geom)
-
                         rows.append({
-                            "geometry": geom,
+                            "geometry": shapely.geometry.mapping(geom),
                             "properties": {
                                 "id": str(i),
-                                "area": area  # Add the area in m² to the properties
+                                "area": area * 0.0001, # Add the area in hectares
+                                "perimeter": perimeter, # Add the perimeter in meters
                             }
                         })
                         i += 1
                     
-                    dst.writerecords(rows)
                     pbar.update(1)
+
+    if format == "Parquet":
+        timestamp = tags.get("TIFFTAG_DATETIME", None)
+        if timestamp is not None:
+            pattern = re.compile(r"^(\d{4})[:-](\d{2})[:-](\d{2})[T\s](\d{2}):(\d{2}):(\d{2}).+$")
+            if pattern.match(timestamp):
+                timestamp = re.sub(pattern, r"\1-\2-\3T\4:\5:\6Z", timestamp)
+            else:
+                print("WARNING: Unable to parse timestamp from TIFFTAG_DATETIME tag.")
+                timestamp = None
+    
+        config = collection = {"fiboa_version": "0.2.0"}
+        columns = ["geometry", "determination_method"] + list(schema["properties"].keys())
+        gdf = features_to_dataframe(rows, columns)
+        gdf.set_crs(original_crs, inplace=True, allow_override=True)
+        gdf["determination_method"] = "auto-imagery"
+        if timestamp is not None:
+            gdf["determination_datetime"] = timestamp
+            columns.append("determination_datetime")
+        
+        create_parquet(gdf, columns, collection, out, config, compression = "brotli")
+    else:
+        with fiona.open(out, 'w', format, schema=schema, crs=original_crs) as dst:
+            dst.writerecords(rows)
 
     print(f"Finished polygonizing output at {out} in {time.time() - tic:.2f}s")


### PR DESCRIPTION
Closes #53 and #26

inference download/run:
- Gets last timestamp from STAC Items, passes them through the TIFF files via TIFFTAG_DATETIME metadata.

inference polygonize:
- Creates GeoParquet 1.1 files compliant to fiboa using fiboa CLI code.
- Adds columns determination_datetime, determination_method, perimeter.
- area was generally changed from m² to ha.
- Other file formats are also "fiboa compliant" (with regards to the columns).

Drawback:
- All other non-Parquet formats are also written in one chunk now, instead of writing them more memory efficient per window. Implementing two different ways of writing the files depending on the format would result in relatively complex code...

Example: 
![{E4EB1F27-12FC-4058-BD0E-52391069E1F5}](https://github.com/user-attachments/assets/972716cc-a199-4c14-a7e2-b8ca099f8d2f)