### PR TITLE
Add max_size to ploygonize command #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ Options:
                      unit of the CRS, e.g. meters for Sentinel-2 imagery in
                      UTM. Set to 0 to disable simplification.  [default: 15]
   --min_size FLOAT   Minimum area size in square meters to include in the
-                     output.  [default: 500]
+                     output. Set to 0 to disable.  [default: 500]
+  --max_size FLOAT   Maximum area size in square meters to include in the
+                     output. Disabled by default.
   -f, --overwrite    Overwrite outputs if they exist.
   --close_interiors  Remove the interiors holes in the polygons.
   --help             Show this message and exit.

--- a/src/ftw_cli/cli.py
+++ b/src/ftw_cli/cli.py
@@ -111,12 +111,13 @@ def inference_run(input, model, out, resize_factor, gpu, patch_size, batch_size,
 @click.argument('input', type=click.Path(exists=True), required=True)
 @click.option('--out', '-o', type=str, default=None, help="Output filename for the polygonized data. If not given defaults to the name of the input file with parquet extension. " + SUPPORTED_POLY_FORMATS_TXT)
 @click.option('--simplify', type=float, default=15, show_default=True, help="Simplification factor to use when polygonizing in the unit of the CRS, e.g. meters for Sentinel-2 imagery in UTM. Set to 0 to disable simplification.")
-@click.option('--min_size', type=float, default=500, show_default=True, help="Minimum area size in square meters to include in the output.")
+@click.option('--min_size', type=float, default=500, show_default=True, help="Minimum area size in square meters to include in the output. Set to 0 to disable.")
+@click.option('--max_size', type=float, default=None, show_default=True, help="Maximum area size in square meters to include in the output. Disabled by default.")
 @click.option('--overwrite', '-f', is_flag=True, help="Overwrite outputs if they exist.")
 @click.option('--close_interiors', is_flag=True, help="Remove the interiors holes in the polygons.")
-def inference_polygonize(input, out, simplify, min_size, overwrite, close_interiors):
+def inference_polygonize(input, out, simplify, min_size, max_size, overwrite, close_interiors):
     from ftw_cli.polygonize import polygonize
-    polygonize(input, out, simplify, min_size, overwrite, close_interiors)
+    polygonize(input, out, simplify, min_size, max_size, overwrite, close_interiors)
 
 inference.add_command(inference_download)
 inference.add_command(inference_polygonize)

--- a/src/ftw_cli/polygonize.py
+++ b/src/ftw_cli/polygonize.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 from .cfg import SUPPORTED_POLY_FORMATS_TXT
 
 
-def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
+def polygonize(input, out, simplify, min_size, max_size, overwrite, close_interiors):
     """Polygonize the output from inference."""
 
     print(f"Polygonizing input file: {input}")
@@ -103,7 +103,7 @@ def polygonize(input, out, simplify, min_size, overwrite, close_interiors):
                         perimeter = geom_proj_meters.length
                         
                         # Only include geometries that meet the minimum size requirement
-                        if area < min_size:
+                        if area < min_size or (max_size is not None and area > max_size):
                             continue
 
                         rows.append({


### PR DESCRIPTION
Implements #72 

I chose None as default, which disables the max_size paramater. I'm not sure we can find a reasonable default value that fits for all use cases, so maybe users should specify it explicitly.

If that looks good, happy to merge and release.