### PR TITLE
add wget to env.yml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -7,3 +7,4 @@ dependencies:
   - gdal>=3.11
   - libgdal-arrow-parquet>=3.11
   - notebook
+  - wget

--- a/env.yml
+++ b/env.yml
@@ -2,8 +2,8 @@ name: ftw
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python>=3.10,<3.12
   - pip
-  - gdal
-  - libgdal-arrow-parquet
+  - gdal>=3.11
+  - libgdal-arrow-parquet>=3.11
   - notebook


### PR DESCRIPTION
Per the error I just got when trying to run the example in the readme to download a pretrained checkpoint. The command was
`wget https://github.com/fieldsoftheworld/ftw-baselines/releases/download/v1/3_Class_FULL_FTW_Pretrained.ckpt`

And the error I got was 
`-bash: wget: command not found`

Probably working for others since wget was already on computer, but good to include in the environment for future users. 