### PR TITLE
adding wget to env.yaml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -7,3 +7,4 @@ dependencies:
   - gdal>=3.11
   - libgdal-arrow-parquet>=3.11
   - notebook
+  - wget


### PR DESCRIPTION
Per the error I just got when trying to run the example in the readme to download a pretrained checkpoint. The command was
`wget https://github.com/fieldsoftheworld/ftw-baselines/releases/download/v1/3_Class_FULL_FTW_Pretrained.ckpt`
And the error I got was
`-bash: wget: command not found`
Probably working for others since wget was already on computer, but good to include in the environment for future users.