### PR TITLE
add ftw model download command

### DIFF
--- a/src/ftw_cli/cli.py
+++ b/src/ftw_cli/cli.py
@@ -1,6 +1,8 @@
 import click
+import wget
 
 from .cfg import ALL_COUNTRIES, SUPPORTED_POLY_FORMATS_TXT
+from .types import ModelVersions
 
 # Imports are in the functions below to speed-up CLI startup time
 # Some of the ML related imports (presumable torch) are very slow
@@ -70,6 +72,13 @@ def model_test(model, dir, gpu, countries, postprocess, iou_threshold, out, mode
     from ftw_cli.model import test
     test(model, dir, gpu, countries, postprocess, iou_threshold, out, model_predicts_3_classes, test_on_3_classes, temporal_options, cli_args)
 
+@model.command("download", help="Download model checkpoints")
+@click.option("--type", type=click.Choice(ModelVersions), default=ModelVersions.TWO_CLASS_CCBY, help="Short model name corresponding to a .ckpt file in github.")
+def model_download(type: ModelVersions):
+    github_url = f"https://github.com/fieldsoftheworld/ftw-baselines/releases/download/v1/{type.value}"
+    print(f"Downloading {github_url} to {type.value}")
+    wget.download(github_url)
+
 model.add_command(model_fit)
 model.add_command(model_test)
 
@@ -118,6 +127,7 @@ def inference_run(input, model, out, resize_factor, gpu, patch_size, batch_size,
 def inference_polygonize(input, out, simplify, min_size, max_size, overwrite, close_interiors):
     from ftw_cli.polygonize import polygonize
     polygonize(input, out, simplify, min_size, max_size, overwrite, close_interiors)
+
 
 inference.add_command(inference_download)
 inference.add_command(inference_polygonize)

--- a/src/ftw_cli/types.py
+++ b/src/ftw_cli/types.py
@@ -1,0 +1,9 @@
+import enum
+
+
+class ModelVersions(enum.StrEnum):
+    """Mapping from short_name to .ckpt file in github."""
+    TWO_CLASS_CCBY = "2_Class_CCBY_FTW_Pretrained.ckpt"
+    TWO_CLASS_FULL = "2_Class_FULL_FTW_Pretrained.ckpt"
+    THREE_CLASS_CCBY = "3_Class_CCBY_FTW_Pretrained.ckpt"
+    THREE_CLASS_FULL = "3_Class_FULL_FTW_Pretrained.ckpt"


### PR DESCRIPTION
Adds the `ftw model download` CLI command which uses `wget` to download a model checkpoint.  Closes #66.

I'm not sure what the best model is to download by default, and I'm open to suggestions on model short names (see the `ModelVersions` enum).

```shell
❯ ftw model download --help
Usage: ftw model download [OPTIONS]

  Download model checkpoints

Options:
  --type [TWO_CLASS_CCBY|TWO_CLASS_FULL|THREE_CLASS_CCBY|THREE_CLASS_FULL]
                                  Short model name corresponding to a .ckpt
                                  file in github.
  --help                          Show this message and exit.
```