### PR TITLE
Delineate Anything

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Python version ${{ matrix.python-version }}
         run: conda install python=${{ matrix.python-version }}
       - name: Install Python dependencies
-        run: pip install -e .[dev]
+        run: pip install -e .[all]
       - name: Download model
         run: wget https://github.com/fieldsoftheworld/ftw-baselines/releases/download/v1/3_Class_FULL_FTW_Pretrained.ckpt
       - name: Execute help tests

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ or for development that includes testing:
 pip install -e .[dev]
 
 # setup pre-commit
-pre-commit configure
+pre-commit install
 ```
 
 This repo uses pre-commit to automatically lint code as you write commits.  You may manually run the linter with `pre-commit run --all-files`.  To confirm you properly downloaded the FTW CLI, run `ftw` in your command line, and you should see the following output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,15 @@ Issues = "https://github.com/fieldsoftheworld/ftw-baselines/issues"
 Changelog = "https://github.com/fieldsoftheworld/ftw-baselines/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+delineate-anything = [
+  "ultralytics<9.0"
+]
 dev = [
     "ruff",        # Code formatting tool
     "pytest",      # Testing framework
+]
+all = [
+    "ftw-tools[dev,delineate-anything]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Changelog = "https://github.com/fieldsoftheworld/ftw-baselines/blob/main/CHANGEL
 
 [project.optional-dependencies]
 delineate-anything = [
-  "ultralytics<9.0"
+  "ultralytics>8.3.0,<9.0",
 ]
 dev = [
     "ruff",        # Code formatting tool

--- a/src/ftw/__init__.py
+++ b/src/ftw/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["datamodules", "datasets", "metrics", "trainers", "utils"]
+__all__ = ["datamodules", "datasets", "metrics", "models", "trainers", "utils"]

--- a/src/ftw/models/delineate_anything.py
+++ b/src/ftw/models/delineate_anything.py
@@ -1,0 +1,127 @@
+from typing import Literal
+
+import geopandas as gpd
+import rasterio
+import shapely.geometry
+import shapely.ops
+import torch
+import torch.nn as nn
+import torchvision.transforms.v2 as T
+
+try:
+    import ultralytics
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "ultralytics is not installed. Please install it with 'pip install ultralytics'."
+    )
+
+try:
+    import huggingface_hub
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "huggingface_hub is not installed. Please install it with 'pip install huggingface_hub'."
+    )
+
+
+class DelineateAnything:
+    """DelineateAnything model for delineating fields in satellite imagery."""
+
+    repo = "MykolaL/DelineateAnything"
+    revision = "c218e08349039afadc9bed3ff46f5cc7f69d9aa9"
+    transforms = nn.Sequential(
+        T.Lambda(lambda x: x[:, :3, ...]),
+        T.ToDtype(torch.float),
+        T.Lambda(lambda x: x / 3000.0),
+        T.Lambda(lambda x: x.clip(0, 1)),
+        T.ConvertImageDtype(torch.float32),
+    )
+
+    def __init__(
+        self,
+        model: Literal[
+            "DelineateAnything-S", "DelineateAnything"
+        ] = "DelineateAnything-S",
+        image_size: tuple[int, int] | int = 320,
+        max_detections: int = 50,
+        iou_threshold: float = 0.6,
+        conf_threshold: float = 0.1,
+        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    ) -> None:
+        """Initialize the DelineateAnything model.
+
+        Args:
+            model (str): The model variant to use, either "DelineateAnything-S" or "DelineateAnything".
+            image_size (tuple[int, int] | int): The size of the input images. If an int is provided, it will be used for both width and height.
+            max_detections (int): Maximum number of detections per image.
+            iou_threshold (float): Intersection over Union threshold for filtering predictions.
+            conf_threshold (float): Confidence threshold for filtering predictions.
+            device (str): Device to run the model on, either "cuda" or "cpu".
+        """
+        super().__init__()
+        self.image_size = (
+            (image_size, image_size) if isinstance(image_size, int) else image_size
+        )
+        self.max_detections = max_detections
+        self.iou_threshold = iou_threshold
+        self.conf_threshold = conf_threshold
+        self.device = device
+
+        self.checkpoint_path = huggingface_hub.hf_hub_download(
+            repo_id=self.repo, revision=self.revision, filename=f"{model}.pt"
+        )
+        self.model = ultralytics.YOLO(self.checkpoint_path).to(device)
+        self.model.eval()
+        self.transforms.eval()
+        self.transforms = self.transforms.to(device)
+
+    def polygonize(
+        self,
+        result: ultralytics.engine.results.Results,
+        transform: rasterio.Affine,
+        crs=rasterio.CRS,
+    ) -> gpd.GeoDataFrame:
+        """Convert the model predictions to a GeoDataFrame of georeferenced polygons.
+
+        Args:
+            result (ultralytics.engine.results.Results): The results from the model prediction.
+            transform (rasterio.Affine): The affine transformation to convert pixel coordinates to geographic coordinates.
+            crs (rasterio.CRS): The coordinate reference system of the output GeoDataFrame.
+
+        Returns:
+            gpd.GeoDataFrame: A GeoDataFrame containing the polygons of the delineated fields.
+        """
+
+        def pixel_to_geo(x, y, z=None):
+            return transform * (x, y)
+
+        df = result.to_df()
+        df["geometry"] = df["segments"].apply(
+            lambda x: shapely.geometry.Polygon(zip(x["y"], x["x"]))
+        )
+        df["geometry"] = df["geometry"].apply(
+            lambda geom: shapely.ops.transform(pixel_to_geo, geom)
+        )
+        df.drop(["name", "class", "box", "segments"], axis=1, inplace=True)
+        return gpd.GeoDataFrame(df, geometry=df["geometry"], crs=crs)
+
+    def __call__(self, image: torch.Tensor) -> list[ultralytics.engine.results.Results]:
+        """Forward pass through the model.
+
+        Args:
+            image (torch.Tensor): The input image tensor, expected to be in the format [C, H, W] and normalized.
+
+        Returns:
+            list[ultralytics.engine.results.Results]: A list of results containing the model predictions.
+        """
+        image = self.transforms(image.to(self.device))
+        results = self.model.predict(
+            image,
+            imgsz=self.image_size,
+            conf=self.conf_threshold,
+            max_det=self.max_detections,
+            iou=self.iou_threshold,
+            device=self.device,
+            half=True,
+            verbose=False,
+        )
+        return results

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -1,0 +1,37 @@
+import geopandas as gpd
+import pytest
+import rasterio
+import torch
+
+pytest.importorskip("ultralytics")
+
+
+def test_delineate_anything():
+    import ultralytics
+
+    from ftw.models.delineate_anything import DelineateAnything
+
+    device = "cpu"
+    model = DelineateAnything(
+        model="DelineateAnything-S",
+        image_size=(320, 320),
+        max_detections=50,
+        iou_threshold=0.6,
+        conf_threshold=0.1,
+        device=device,
+    )
+
+    # test model inference
+    x = torch.randn(2, 3, 256, 256, requires_grad=False, device=device)
+    with torch.inference_mode():
+        results = model(x)
+
+    assert len(results) == 2
+    assert isinstance(results[0], ultralytics.engine.results.Results)
+
+    # test conversion of results to polygons
+    transform = rasterio.Affine(1, 0, 0, 0, -1, 0)
+    crs = rasterio.CRS.from_epsg(4326)
+    gdf = model.polygonize(results[0], transform, crs)
+    assert isinstance(gdf, gpd.GeoDataFrame)
+    assert gdf.crs == crs


### PR DESCRIPTION
This PR adds a class for running the [Delineate Anything](https://lavreniuk.github.io/Delineate-Anything/) model pretrained for instance segmentation of field boundaries in single RGB Sentinel-2 imagery. 

The models have two variants: `DelineateAnything` and `DelineateAnything-S`. They are Ultralytics YOLO instance segmentation models. Notably the small model runs quite fast on CPU for those wanting to run locally.

I've added a new extras to `ftw-tools` which can be installed like `pip install 'ftw-tools[delineate-anything]'`

Minimal usage to run the model and convert the predictions to georeferenced polygons in a geopandas dataframe:

```python
import torch
import rasterio
from ftw.models.delineate_anything import DelineateAnything

model = DelineateAnything(
    model="DelineateAnything-S",
    image_size=320,
    max_detections=25,
    conf_threshold=0.1,
    iou_threshold=0.6,
    device="cpu"
)
path = "path/to/sentinel-2_image.tiff"
with rasterio.open(path) as src:
    transform = src.transform
    crs = src.crs
    image = torch.from_numpy(src.read([1, 2, 3]))

results = model(image.unsqueeze(dim=0))
gdf = model.polygonize(results[0], transform=transform, crs=crs)
gdf

"""
confidence | geometry
-- | --
0.52686 | POLYGON ((2.94731 49.48701, 2.94752 49.48701, ...
0.43042 | POLYGON ((2.94709 49.48301, 2.94736 49.48301, ...
0.35083 | POLYGON ((2.9544 49.48491, 2.95456 49.48491, 2...
0.32812 | POLYGON ((2.94452 49.48242, 2.94575 49.48242, ...
0.31201 | POLYGON ((2.94645 49.48242, 2.94731 49.48242, ...
0.23938 | POLYGON ((2.95569 49.48242, 2.95767 49.48242, ...
0.23474 | POLYGON ((2.94538 49.48572, 2.94559 49.48572, ...
0.20496 | POLYGON ((2.95182 49.48782, 2.95203 49.48782, ...
0.20020 | POLYGON ((2.95182 49.48318, 2.95214 49.48318, ...
0.18652 | POLYGON ((2.94409 49.48842, 2.94425 49.48842, ...
0.18042 | POLYGON ((2.95246 49.49258, 2.95263 49.49258, ...
0.16577 | POLYGON ((2.9443 49.48345, 2.94446 49.48345, 2...
0.15942 | POLYGON ((2.95053 49.48242, 2.95198 49.48242, ...
0.14246 | POLYGON ((2.94452 49.48458, 2.94473 49.48458, ...
0.14185 | POLYGON ((2.94623 49.49226, 2.94645 49.49226, ...
0.13770 | POLYGON ((2.94409 49.48496, 2.94425 49.48496, ...
0.13489 | POLYGON ((2.94409 49.49036, 2.94425 49.49036, ...
0.13403 | POLYGON ((2.9486 49.48231, 2.9494 49.48231, 2....
0.13159 | POLYGON ((2.9544 49.48491, 2.95456 49.48491, 2...
0.12634 | POLYGON ((2.9544 49.48696, 2.95579 49.48696, 2...
0.12494 | POLYGON ((2.95246 49.49253, 2.95273 49.49253, ...
0.12177 | POLYGON ((2.95182 49.4835, 2.95456 49.4835, 2....
0.12103 | POLYGON ((2.94452 49.48242, 2.94575 49.48242, ...
0.10760 | POLYGON ((2.95053 49.49285, 2.95069 49.49285, ...
0.10742 | POLYGON ((2.95053 49.49285, 2.95069 49.49285, ...
"""
```

Plotting the georeferenced polygons with `gdf.explore` to validate shows the following for example:

<img width="756" alt="image" src="https://github.com/user-attachments/assets/da7cfbf7-e183-4d59-a52d-8898d2a6084f" />


Some example predictions using the [supervision](https://supervision.roboflow.com/latest/) package for plotting:

![image](https://github.com/user-attachments/assets/fdd596a5-42f1-4ab6-ab6b-37f9d32c00e0)
![image](https://github.com/user-attachments/assets/6cb4f35a-30cd-4bc7-9bb2-b9fb53408558)
![image](https://github.com/user-attachments/assets/50f792c9-a57b-49cf-8a0c-7b89134bfdc1)
![image](https://github.com/user-attachments/assets/bb06aa0f-efde-4e8d-81d0-fb4e911fbb22)
![image](https://github.com/user-attachments/assets/d5e09011-9a8b-4f82-9409-b5a1ddea1652)
![image](https://github.com/user-attachments/assets/cc470272-ab78-4d2a-9304-431ee9aae646)
