### PR TITLE
Switch to EarthSearch Download instead of Planetary Computer 

### DIFF
--- a/ftw_tools/download/download_img.py
+++ b/ftw_tools/download/download_img.py
@@ -37,16 +37,16 @@ def get_item(id: str) -> pystac.Item:
 
         year = date_str[:4]
         month = date_str[4:6]
+        # Remove leading zero from month to get valid S3 path
+        month = str(int(month))
 
         uri = (
             f"{AWS_SENTINEL_URL}/"
             f"sentinel-s2-l2a-cogs/{utm_zone}/{lat_band}/{grid_square}/"
             f"{year}/{month}/{id}/{id}.json"
         )
-
     else:
         uri = id
-
     item = pystac.Item.from_file(uri)
 
     return item

--- a/ftw_tools/settings.py
+++ b/ftw_tools/settings.py
@@ -2,7 +2,7 @@
 
 AWS_SENTINEL_URL = "https://sentinel-cogs.s3.us-west-2.amazonaws.com"
 COLLECTION_ID = "sentinel-2-l2a"
-BANDS_OF_INTEREST = ["B04", "B03", "B02", "B08"]
+BANDS_OF_INTEREST = ["red", "green", "blue", "nir"]
 
 # Supported file formats for the inference polygon command
 SUPPORTED_POLY_FORMATS_TXT = "Available file extensions: .parquet (GeoParquet, fiboa-compliant), .fgb (FlatGeoBuf), .gpkg (GeoPackage), .geojson / .json / .ndjson (GeoJSON)"

--- a/ftw_tools/settings.py
+++ b/ftw_tools/settings.py
@@ -1,5 +1,6 @@
-# Microsoft Planetary Computer API URL + collection id + bands for inference download command
-MSPC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
+# Collection id + bands for inference download command
+
+AWS_SENTINEL_URL = "https://sentinel-cogs.s3.us-west-2.amazonaws.com"
 COLLECTION_ID = "sentinel-2-l2a"
 BANDS_OF_INTEREST = ["B04", "B03", "B02", "B08"]
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -18,8 +18,8 @@ def test_inference_download():  # create_input
     result = runner.invoke(
         inference_download,
         [
-            "--win_a=S2B_MSIL2A_20210617T100559_R022_T33UUP_20210624T063729",
-            "--win_b=S2B_MSIL2A_20210925T101019_R022_T33UUP_20210926T121923",
+            "--win_a=S2B_33UUP_20210617T100559_0_L2A",
+            "--win_b=S2B_33UUP_20210925T101019_0_L2A",
             "--bbox=13.0,48.0,13.2,48.2",
             "-o",
             inference_image,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -13,13 +13,13 @@ from ftw_tools.cli import (
 def test_inference_download():  # create_input
     runner = CliRunner()
 
-    # Download imagery by ID from MS Planetary Computer
+    # Download imagery by ID from EarthSearch
     inference_image = "inference_imagery/austria_example.tif"
     result = runner.invoke(
         inference_download,
         [
-            "--win_a=S2B_33UUP_20210617T100559_0_L2A",
-            "--win_b=S2B_33UUP_20210925T101019_0_L2A",
+            "--win_a=S2B_33UUP_20210617_1_L2A",
+            "--win_b=S2B_33UUP_20210925_1_L2A",
             "--bbox=13.0,48.0,13.2,48.2",
             "-o",
             inference_image,


### PR DESCRIPTION
Note this is a breaking change to switch the download source from the planetary computer to earthsearch. 

This is breaking because its a different download source and formatting and variable names are different between the two. 


As discussed in #123 this fully transitions all logic in this repo to use EarthSearch, the spirit of the `get_item` function remains the same and its able to accommodate formatting an ID or `"earthsearch:s3_path"` which the crop calendar will return once #123 is merged in. 

This PR is independent from the changes in #123 but is related, I'm not sure it its preferred for this to merge into main or be merged into #123? happy to confirm with the ways people are used to working in this repo 

**Future Considerations**

As the CLI develops and we move towards users providing a bounding box and year they want to run inference over, it might be nice to investigating simplifying the code to query and download the image in one step. 