### PR TITLE
Fix license warning during python build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ftw-tools"
 version = "2.0.0"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 description = "Fields of The World (FTW) Command Line Interface (CLI) for data management, ML processing, and more."
 readme = 'README.md'
 authors = [
@@ -18,7 +19,6 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
 ]
 


### PR DESCRIPTION
The Python build during release leads to:

```
!!
  dist._finalize_license_expression()
C:\Users\Matthias Mohr\AppData\Local\Temp\build-env-h_nv43_0\Lib\site-packages\setuptools\dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

This fixes the issue.