### PR TITLE
Align requirements in env.yaml and pyproject.toml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.11,<3.13
   - pip
-  - gdal>=3.11
-  - libgdal-arrow-parquet>=3.11
+  - gdal>=3.10,<3.11
+  - libgdal-arrow-parquet>=3.10,<3.11
   - notebook
   - wget

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 python = ">=3.11,<3.13"
 
 # System dependencies (from env.yml) - pinned for stability
-gdal = ">=3.10,<3.12"
-libgdal-arrow-parquet = ">=3.10,<3.12"
+gdal = ">=3.10,<3.11"
+libgdal-arrow-parquet = ">=3.10,<3.11"
 notebook = ">=7.0,<8.0"
 
 # Core Python packages
@@ -95,8 +95,8 @@ tensorboard = ">=2.15,<3.0"
 
 # Geospatial stack (critical: install together for compatibility)
 geopandas = ">=0.14,<2.0"
-rasterio = ">=1.3,<2.0"
-fiona = ">=1.9,<2.0"
+rasterio = ">=1.4.3,<2.0"
+fiona = ">=1.10,<2.0"
 pyproj = ">=3.6,<4.0"
 
 # Data processing (moved from PyPI based on analysis)


### PR DESCRIPTION
GDAL requirements were not aligned, was probably introduced when error when migrating to Pixi.