### PR TITLE
Delineate Anything Inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ftw_tools.egg-info/
 /austria_example_output_full.gpkg
 /austria_example_output_full.tif
 /dist
+weights/

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -428,7 +428,7 @@ def scene_selection(year, cloud_cover_max, bbox, buffer_days, out):
     help="Download 2 Sentinel-2 scenes & stack them in a single file for inference.",
 )
 @click.option("--win_a", type=str, required=True, help=WIN_HELP.format(x="A"))
-@click.option("--win_b", type=str, required=True, help=WIN_HELP.format(x="B"))
+@click.option("--win_b", type=str, default=None, help=WIN_HELP.format(x="B"))
 @click.option(
     "--out", "-o", type=str, required=True, help="Filename to save results to"
 )

--- a/ftw_tools/download/download_img.py
+++ b/ftw_tools/download/download_img.py
@@ -11,8 +11,8 @@ import pandas as pd
 import planetary_computer as pc
 import pystac
 import pystac_client
-import rioxarray  # seems unused but is needed
-import xarray as xr
+import rioxarray  # noqa: F401
+import xarray as xr  # noqa: F401
 from pystac.extensions.eo import EOExtension as eo
 from shapely.geometry import box, shape
 from tenacity import retry, stop_after_attempt, wait_random_exponential

--- a/ftw_tools/models/baseline_inference.py
+++ b/ftw_tools/models/baseline_inference.py
@@ -261,7 +261,7 @@ def run_instance_segmentation(
     )
 
     # Load dataset
-    dataset = SingleRasterDataset(input, transforms=preprocess)
+    dataset = SingleRasterDataset(input)
     sampler = GridGeoSampler(dataset, size=patch_size, stride=stride)
     dataloader = DataLoader(
         dataset,
@@ -278,7 +278,6 @@ def run_instance_segmentation(
         total=len(dataloader),
         desc=f"Running FTW instance segmentation inference on {input}",
     ):
-        b, c, h, w = batch["image"].shape
         images = batch["image"].to(device)
         predictions = model(images)
 
@@ -290,6 +289,7 @@ def run_instance_segmentation(
 
         # Convert instance predictions to polygons
         for image, pred, bounds in zip(images, predictions, bboxes):
+            h, w = image.shape[:2]
             transform = from_bounds(
                 west=bounds.minx,
                 south=bounds.miny,

--- a/ftw_tools/models/baseline_inference.py
+++ b/ftw_tools/models/baseline_inference.py
@@ -1,13 +1,20 @@
 import math
 import os
+import re
 import time
+from typing import Literal
 
+import geopandas as gpd
 import kornia.augmentation as K
 import numpy as np
+import pandas as pd
 import rasterio
+import shapely
 import torch
+from fiboa_cli.parquet import create_parquet
 from kornia.constants import Resample
 from rasterio.enums import ColorInterp
+from rasterio.transform import from_bounds
 from torch.utils.data import DataLoader
 from torchgeo.datasets import stack_samples
 from torchgeo.samplers import GridGeoSampler
@@ -18,14 +25,11 @@ from ftw_tools.torchgeo.datasets import SingleRasterDataset
 from ftw_tools.torchgeo.trainers import CustomSemanticSegmentationTask
 
 
-def run(
+def setup_inference(
     input,
-    model,
     out,
-    resize_factor,
     gpu,
     patch_size,
-    batch_size,
     padding,
     overwrite,
     mps_mode,
@@ -36,8 +40,6 @@ def run(
         )
 
     # IO related sanity checks
-    assert os.path.exists(model), f"Model file {model} does not exist."
-    assert model.endswith(".ckpt"), "Model file must be a .ckpt file."
     assert os.path.exists(input), f"Input file {input} does not exist."
     assert input.endswith(".tif") or input.endswith(".vrt"), (
         "Input file must be a .tif or .vrt file."
@@ -58,11 +60,11 @@ def run(
 
     # Load the input raster
     with rasterio.open(input) as src:
-        input_height, input_width = src.shape
+        input_shape = src.shape
+        input_height, input_width = input_shape[0], input_shape[1]
         print(f"Input image size: {input_height}x{input_width} pixels (HxW)")
         profile = src.profile
         transform = profile["transform"]
-        tags = src.tags()
 
     # Determine the default patch size
     if patch_size is None:
@@ -87,6 +89,29 @@ def run(
     assert stride > 64, (
         "Patch size minus two times the padding must be greater than 64."
     )
+
+    return device, transform, input_shape, patch_size, stride
+
+
+def run(
+    input,
+    model,
+    out,
+    resize_factor,
+    gpu,
+    patch_size,
+    batch_size,
+    num_workers,
+    padding,
+    overwrite,
+    mps_mode,
+):
+    device, transform, input_shape, patch_size, stride = setup_inference(
+        input, out, gpu, patch_size, padding, overwrite, mps_mode
+    )
+
+    assert os.path.exists(model), f"Model file {model} does not exist."
+    assert model.endswith(".ckpt"), "Model file must be a .ckpt file."
 
     # Load task
     tic = time.time()
@@ -119,12 +144,12 @@ def run(
         dataset,
         sampler=sampler,
         batch_size=batch_size,
-        num_workers=6,
+        num_workers=num_workers,
         collate_fn=stack_samples,
     )
 
     # Run inference
-    output_mask = np.zeros((input_height, input_width), dtype=np.uint8)
+    output_mask = np.zeros(input_shape, dtype=np.uint8)
     dl_enumerator = tqdm(dataloader)
 
     for batch in dl_enumerator:
@@ -165,6 +190,10 @@ def run(
             ]
             output_mask[ptop:pbottom, pleft:pright] = inp
 
+    with rasterio.open(input) as src:
+        profile = src.profile
+        tags = src.tags()
+
     # Save predictions
     profile.update(
         {
@@ -187,3 +216,161 @@ def run(
         dst.write(output_mask, 1)
 
     print(f"Finished inference and saved output to {out} in {time.time() - tic:.2f}s")
+
+
+@torch.inference_mode()
+def run_instance_segmentation(
+    input: str,
+    model: Literal["DelineateAnything-S", "DelineateAnything"],
+    out: str,
+    gpu: int | None = None,
+    num_workers: int = 4,
+    image_size: int = 320,
+    patch_size: int = 256,
+    batch_size: int = 2,
+    max_detections: int = 50,
+    iou_threshold: float = 0.6,
+    conf_threshold: float = 0.1,
+    padding: int | None = None,
+    overwrite: bool = False,
+    mps_mode: bool = False,
+    simplify: int = 15,
+    min_size: int | None = 500,
+    max_size: int | None = None,
+    close_interiors: bool = True,
+):
+    from .delineate_anything import DelineateAnything
+
+    assert model in ["DelineateAnything", "DelineateAnything-S"], (
+        "Model must be either DelineateAnything or DelineateAnything-S."
+    )
+
+    device, _, _, patch_size, stride = setup_inference(
+        input, out, gpu, patch_size, padding, overwrite, mps_mode
+    )
+
+    # Load task
+    tic = time.time()
+    model = DelineateAnything(
+        model=model,
+        image_size=image_size,
+        max_detections=max_detections,
+        iou_threshold=iou_threshold,
+        conf_threshold=conf_threshold,
+        device=device,
+    )
+
+    # Load dataset
+    dataset = SingleRasterDataset(input, transforms=preprocess)
+    sampler = GridGeoSampler(dataset, size=patch_size, stride=stride)
+    dataloader = DataLoader(
+        dataset,
+        sampler=sampler,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        collate_fn=stack_samples,
+    )
+
+    # Run inference
+    polygons = []
+    for batch in tqdm(
+        dataloader,
+        total=len(dataloader),
+        desc=f"Running FTW instance segmentation inference on {input}",
+    ):
+        b, c, h, w = batch["image"].shape
+        images = batch["image"].to(device)
+        predictions = model(images)
+
+        # torchgeo>=0.6 refers to the bounding box as "bounds" instead of "bbox"
+        if "bounds" in batch and batch["bounds"] is not None:
+            bboxes = batch["bounds"]
+        else:
+            bboxes = batch["bbox"]
+
+        # Convert instance predictions to polygons
+        for image, pred, bounds in zip(images, predictions, bboxes):
+            transform = from_bounds(
+                west=bounds.minx,
+                south=bounds.miny,
+                east=bounds.maxx,
+                north=bounds.maxy,
+                height=h,
+                width=w,
+            )
+            polygons.append(model.polygonize(pred, transform, dataset.crs))
+
+    polygons = [p for p in polygons if p is not None]
+    polygons = gpd.GeoDataFrame(pd.concat(polygons), crs=dataset.crs)
+
+    # Convert polygons to fiboa format before writing to file
+    with rasterio.open(input) as src:
+        timestamp = src.tags().get("TIFFTAG_DATETIME", None)
+    polygons = convert_to_fiboa(
+        polygons, out, timestamp, simplify, min_size, max_size, close_interiors
+    )
+
+    print(f"Finished inference and saved output to {out} in {time.time() - tic:.2f}s")
+
+
+def convert_to_fiboa(
+    polygons: gpd.GeoDataFrame,
+    output: str,
+    timestamp: str | None,
+    simplify: int = 0,
+    min_size: int | None = None,
+    max_size: int | None = None,
+    close_interiors: bool = True,
+) -> gpd.GeoDataFrame:
+    """Convert polygons to fiboa format."""
+    src_crs = polygons.crs
+    polygons.to_crs("EPSG:6933", inplace=True)
+
+    # Filter polygons
+    if close_interiors:
+        polygons.geometry = polygons.geometry.exterior
+        polygons.geometry = polygons.geometry.apply(
+            lambda x: shapely.geometry.Polygon(x)
+        )
+
+    if simplify > 0:
+        polygons.geometry = polygons.geometry.simplify(simplify)
+
+    polygons["area"] = polygons.geometry.area
+    polygons["perimeter"] = polygons.geometry.length
+
+    if min_size is not None:
+        polygons = polygons[polygons["area"] >= min_size]
+    if max_size is not None:
+        polygons = polygons[polygons["area"] <= max_size]
+
+    polygons.reset_index(drop=True, inplace=True)
+    polygons["id"] = polygons.index + 1
+
+    # Convert to hectares
+    polygons["area"] = polygons["area"] * 0.0001
+
+    # Fiboa specific formatting
+    polygons["determination_method"] = "auto-imagery"
+
+    config = collection = {"fiboa_version": "0.2.0"}
+    columns = ["id", "area", "perimeter", "determination_method", "geometry"]
+
+    if timestamp is not None:
+        pattern = re.compile(
+            r"^(\d{4})[:-](\d{2})[:-](\d{2})[T\s](\d{2}):(\d{2}):(\d{2}).*$"
+        )
+        if pattern.match(timestamp):
+            timestamp = re.sub(pattern, r"\1-\2-\3T\4:\5:\6Z", timestamp)
+            polygons["determination_datetime"] = timestamp
+            columns.append("determination_datetime")
+        else:
+            print("WARNING: Unable to parse timestamp from TIFFTAG_DATETIME tag.")
+
+    # Convert back to original CRS
+    polygons.to_crs(src_crs, inplace=True)
+
+    # Create parquet
+    create_parquet(polygons, columns, collection, output, config, compression="brotli")
+
+    return polygons

--- a/ftw_tools/torchgeo/datasets.py
+++ b/ftw_tools/torchgeo/datasets.py
@@ -233,7 +233,7 @@ class FTW(NonGeoDataset):
                 print(f"Country directory {country_dir} not found")
                 return False
 
-            chips_fns = list(Path(country_dir).glob(f"chips_*.parquet"))
+            chips_fns = list(Path(country_dir).glob("chips_*.parquet"))
             # boundaries_fns = list(Path(country_dir).glob(f"boundaries_*.parquet"))
             if len(chips_fns) != 1:
                 print(f"Country {country} does not have chips file")

--- a/ftw_tools/utils.py
+++ b/ftw_tools/utils.py
@@ -2,7 +2,6 @@ import hashlib
 import logging
 import os
 
-import numpy as np
 import pandas as pd
 import scipy
 import scipy.stats

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -234,8 +234,6 @@ def test_instance_segmentation_inference_all():
                 "--gpu",
                 "0",
                 "--overwrite",
-                "--conf_threshold",
-                "0.01",
             ],
         )
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
This PR adds the ability to perform downloading of a single image and performing inference using the Delineate Anything models.

The new cli calls are `ftw inference run-instance-segmentation` which performs inference on an already downloaded image and `ftw inference ftw-inference-instance-segmentation-all` which combines

Note that this model is instance segmentation so there is no intermediate mask tif created, the results are converted directly to polygons in fiboa parquet format.

Some examples of the usage:

```shell
ftw inference ftw-inference-instance-segmentation-all S2B_MSIL2A_20210617T100559_R022_T33UUP_20210624T063729 --bbox 13.0,48.0,13.3,48.3  --model DelineateAnything-S --gpu 0 --out_dir outputs
```

```shell
ftw inference run-instance-segmentation inference_imagery/austria_example.tif --model DelineateAnything-S --gpu 0 --out tmp.parquet --patch_size 512 --image_size 1024 --conf_threshold=0.1 --iou_threshold=0.6 --min_size 100 --simplify 15
```

Results are decent, the post-processing and patch size parameters could probably use some tuning though 
<img width="932" height="561" alt="image" src="https://github.com/user-attachments/assets/a28163fc-57e5-413b-a784-b3e39d038829" />
