### PR TITLE
Change aws collection to sentinel-2-c1-l2a from sentinel-2-l2a

### DIFF
--- a/ftw_tools/settings.py
+++ b/ftw_tools/settings.py
@@ -1,7 +1,7 @@
 # Collection id + bands for inference download command
 
 AWS_SENTINEL_URL = "https://sentinel-cogs.s3.us-west-2.amazonaws.com"
-COLLECTION_ID = "sentinel-2-l2a"
+COLLECTION_ID = "sentinel-2-c1-l2a"
 BANDS_OF_INTEREST = ["red", "green", "blue", "nir"]
 
 MSPC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"


### PR DESCRIPTION
Discussion on slack with @m-mohr lead us to realize that we don't actually know real details about sentinel-2-l2a COG's, and I believe we were assuming that they were all collection 1 / processing level 5+. I haven't done hugely extensive testing, but in my experiments just using c1 lead to much better results. The visual looked reasonable, and the polygons were much closer to PC results. 

So I think the transform is actually right, and sentinel-2-l2a collection is doing some weird stuff post-2021. 

This should have much more testing, but putting up the PR in the hopes that we might be able to get a version of the API with this on, etc. If someone else does some basic testing then we can go ahead and merge and see how it goes.