### PR TITLE
Clearer error raised for querying stac for dates in the future

### DIFF
--- a/ftw_tools/download/download_img.py
+++ b/ftw_tools/download/download_img.py
@@ -186,6 +186,13 @@ def query_stac(
     start = (date - pd.Timedelta(days=buffer_days)).strftime("%Y-%m-%d")
     end = (date + pd.Timedelta(days=buffer_days)).strftime("%Y-%m-%d")
 
+    # Check to ensure both start and end aren't in the future
+    today = pd.Timestamp.now().normalize()
+    if pd.Timestamp(start) > today or pd.Timestamp(end) > today:
+        raise ValueError(
+            f"Crop calendar harvest date {date} and buffer days {start}, {end} can't be in the future, try using an earlier calendar year"
+        )
+
     # Format as string
     date_range = f"{start}/{end}"
 

--- a/tests/test_download_img.py
+++ b/tests/test_download_img.py
@@ -37,7 +37,7 @@ def test_query_stac_future_year():
         query_stac(
             bbox=[-93.68708939, 41.9530844, -93.64078526, 41.98070608],
             stac_host="mspc",
-            date=pd.Timestamp("2027-12-31"),
+            date=pd.Timestamp.now() + pd.Timedelta(days=3),
         )
 
 

--- a/tests/test_download_img.py
+++ b/tests/test_download_img.py
@@ -32,6 +32,15 @@ def test_get_item_from_s3_url_single_digit_month():
     assert item.id == "S2B_33UUP_20210925_0_L2A"
 
 
+def test_query_stac_future_year():
+    with pytest.raises(ValueError, match="Crop calendar harvest date"):
+        query_stac(
+            bbox=[-93.68708939, 41.9530844, -93.64078526, 41.98070608],
+            stac_host="mspc",
+            date=pd.Timestamp("2027-12-31"),
+        )
+
+
 @pytest.fixture
 def large_aoi():
     return [13.83984671, -6.73397741, 15.0, -5]


### PR DESCRIPTION
Adds a new value error to close #143, if the date is in the future the stac query won't be run and a more detailed value error will be raised sooner. 

This means that the harvest start + end as well as the buffer dates around those must all be before the current date. 