### PR TITLE
Reworking experiment DataModule and fixing evaluation script

### DIFF
--- a/configs/release/run_eval.py
+++ b/configs/release/run_eval.py
@@ -1,37 +1,38 @@
+import argparse
 import os
 import subprocess
 
 import yaml
 
-if __name__ == "__main__":
-    countries = [
-        "austria",
-        "belgium",
-        "brazil",
-        "cambodia",
-        "corsica",
-        "croatia",
-        "denmark",
-        "estonia",
-        "finland",
-        "france",
-        "germany",
-        "india",
-        "kenya",
-        "latvia",
-        "lithuania",
-        "luxembourg",
-        "netherlands",
-        "portugal",
-        "rwanda",
-        "slovakia",
-        "slovenia",
-        "south_africa",
-        "spain",
-        "sweden",
-        "vietnam",
-    ]
+COUNTRIES = [
+    "austria",
+    "belgium",
+    "brazil",
+    "cambodia",
+    "corsica",
+    "croatia",
+    "denmark",
+    "estonia",
+    "finland",
+    "france",
+    "germany",
+    "india",
+    "kenya",
+    "latvia",
+    "lithuania",
+    "luxembourg",
+    "netherlands",
+    "portugal",
+    "rwanda",
+    "slovakia",
+    "slovenia",
+    "south_africa",
+    "spain",
+    "sweden",
+    "vietnam",
+]
 
+def main(args):
     checkpoints = []
     for root, dirs, files in os.walk("logs/"):
         for file in files:
@@ -53,7 +54,7 @@ if __name__ == "__main__":
 
     for checkpoints_data in checkpoints:
         (checkpoint, model_predicts_classes) = checkpoints_data
-        for country in countries:
+        for country in COUNTRIES:
             if model_predicts_classes == 2:
                 # Test on the same country
                 command = [
@@ -61,7 +62,7 @@ if __name__ == "__main__":
                     "model",
                     "test",
                     "--gpu",
-                    "0",
+                    str(args.gpu),
                     "--dir",
                     "data/ftw",
                     "--model",
@@ -79,7 +80,7 @@ if __name__ == "__main__":
                     "model",
                     "test",
                     "--gpu",
-                    "0",
+                    str(args.gpu),
                     "--dir",
                     "data/ftw",
                     "--model",
@@ -88,7 +89,13 @@ if __name__ == "__main__":
                     "results/experiments-ftw_release-3_classes.csv",
                     "--countries",
                     country,
-                    "--model_predicts_3_classes",
-                    "True",
+                    "--model_predicts_3_classes"
                 ]
                 subprocess.call(command)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run evaluation")
+    parser.add_argument("--gpu", type=int, required=True, help="GPU ID to use")
+    args = parser.parse_args()
+    main(args)

--- a/configs/release/run_eval.py
+++ b/configs/release/run_eval.py
@@ -73,6 +73,8 @@ def main(args):
                     "--countries",
                     country,
                 ]
+                if args.swap_order:
+                    command.append("--swap_order")
                 subprocess.call(command)
             elif model_predicts_classes == 3:
                 # Test on the same country
@@ -92,11 +94,18 @@ def main(args):
                     country,
                     "--model_predicts_3_classes",
                 ]
+                if args.swap_order:
+                    command.append("--swap_order")
                 subprocess.call(command)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run evaluation")
     parser.add_argument("--gpu", type=int, required=True, help="GPU ID to use")
+    parser.add_argument(
+        "--swap_order",
+        action="store_true",
+        help="Whether to swap the order of temporal images",
+    )
     args = parser.parse_args()
     main(args)

--- a/configs/release/run_eval.py
+++ b/configs/release/run_eval.py
@@ -32,6 +32,7 @@ COUNTRIES = [
     "vietnam",
 ]
 
+
 def main(args):
     checkpoints = []
     for root, dirs, files in os.walk("logs/"):
@@ -89,7 +90,7 @@ def main(args):
                     "results/experiments-ftw_release-3_classes.csv",
                     "--countries",
                     country,
-                    "--model_predicts_3_classes"
+                    "--model_predicts_3_classes",
                 ]
                 subprocess.call(command)
 

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -222,6 +222,13 @@ def model_fit(config, ckpt_path, cli_args):
     show_default=True,
     help="Temporal option",
 )
+@click.option(
+    "--swap_order",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Whether to run inference on (window_a, window_b) instead of the default (window_b, window_a).",
+)
 def model_test(
     model,
     countries,
@@ -233,6 +240,7 @@ def model_test(
     model_predicts_3_classes,
     test_on_3_classes,
     temporal_options,
+    swap_order,
 ):
     from ftw_tools.models.baseline_eval import test
 
@@ -247,6 +255,7 @@ def model_test(
         model_predicts_3_classes,
         test_on_3_classes,
         temporal_options,
+        swap_order,
     )
 
 

--- a/ftw_tools/models/baseline_eval.py
+++ b/ftw_tools/models/baseline_eval.py
@@ -5,7 +5,6 @@ import numpy as np
 import torch
 from lightning.pytorch.cli import LightningCLI
 from torch.utils.data import DataLoader
-from torchgeo.datamodules import BaseDataModule
 from torchgeo.trainers import BaseTask
 from torchmetrics import JaccardIndex, MetricCollection, Precision, Recall
 from tqdm import tqdm
@@ -42,7 +41,6 @@ def fit(config, ckpt_path, cli_args):
     # Run the LightningCLI with the constructed arguments
     cli = LightningCLI(
         model_class=BaseTask,
-        datamodule_class=BaseDataModule,
         seed_everything_default=0,
         subclass_mode_model=True,
         subclass_mode_data=True,

--- a/ftw_tools/models/baseline_eval.py
+++ b/ftw_tools/models/baseline_eval.py
@@ -54,7 +54,7 @@ def fit(config, ckpt_path, cli_args):
 
 
 def test(
-    model,
+    model_path,
     dir,
     gpu,
     countries,
@@ -79,7 +79,7 @@ def test(
     print("Loading model")
     tic = time.time()
     trainer = CustomSemanticSegmentationTask.load_from_checkpoint(
-        model, map_location="cpu"
+        model_path, map_location="cpu"
     )
     model = trainer.model.eval().to(device)
     print(f"Model loaded in {time.time() - tic:.2f}s")
@@ -198,5 +198,5 @@ def test(
                 )
         with open(out, "a") as f:
             f.write(
-                f"{model},{countries},{pixel_level_iou},{pixel_level_precision},{pixel_level_recall},{object_precision},{object_recall}\n"
+                f"{model_path},{countries},{pixel_level_iou},{pixel_level_precision},{pixel_level_recall},{object_precision},{object_recall}\n"
             )

--- a/ftw_tools/models/baseline_eval.py
+++ b/ftw_tools/models/baseline_eval.py
@@ -64,6 +64,7 @@ def test(
     model_predicts_3_classes,
     test_on_3_classes,
     temporal_options,
+    swap_order,
 ):
     """Command to test the model."""
     print("Running test command")
@@ -94,6 +95,7 @@ def test(
         transforms=preprocess,
         load_boundaries=test_on_3_classes,
         temporal_options=temporal_options,
+        swap_order=swap_order,
     )
     dl = DataLoader(ds, batch_size=64, shuffle=False, num_workers=12)
     print(f"Created dataloader with {len(ds)} samples in {time.time() - tic:.2f}s")

--- a/ftw_tools/torchgeo/datamodules.py
+++ b/ftw_tools/torchgeo/datamodules.py
@@ -104,7 +104,7 @@ class FTWDataModule(LightningDataModule):
 
         if resize_factor is not None:
             if resize_factor < 1:
-                raise ValueError("Resize factor must be > 1")
+                raise ValueError("Resize factor must be >= 1")
             print(f"Using resize factor of {resize_factor}")
             augs.append(
                 K.Resize(

--- a/ftw_tools/torchgeo/datamodules.py
+++ b/ftw_tools/torchgeo/datamodules.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Optional
 
-import kornia.augmentation as K
 import kornia
+import kornia.augmentation as K
 import torch
 from matplotlib.figure import Figure
 from torch.utils.data import Subset
@@ -17,10 +17,12 @@ def preprocess(sample):
     sample["image"] = sample["image"] / 3000
     return sample
 
+
 def randomChannelShuffle(x):
     if torch.rand(1) < 0.5:
         return x
-    return torch.cat([x[:,4:8], x[:,:4]], dim=1)
+    return torch.cat([x[:, 4:8], x[:, :4]], dim=1)
+
 
 class FTWDataModule(NonGeoDataModule):
     """LightningDataModule implementation for the FTW dataset."""

--- a/ftw_tools/torchgeo/datasets.py
+++ b/ftw_tools/torchgeo/datasets.py
@@ -46,6 +46,7 @@ class FTW(NonGeoDataset):
         checksum: bool = False,
         load_boundaries: bool = False,
         temporal_options: str = "stacked",
+        swap_order: bool = False,
         num_samples: int = -1,
     ) -> None:
         """Initialize a new FTW dataset instance.
@@ -60,6 +61,7 @@ class FTW(NonGeoDataset):
             checksum: if True, check the MD5 of the downloaded files (may be slow)
             load_boundaries: if True, load the 3 class masks with boundaries
             temporal_options : for abalation study, valid option are (stacked, windowA, windowB, median, rgb)
+            swap_order: if True, swap the order of temporal data (i.e. use window A first)
         Raises:
             AssertionError: if ``countries`` argument is invalid
             AssertionError: if ``split`` argument is invalid
@@ -85,6 +87,7 @@ class FTW(NonGeoDataset):
         self.load_boundaries = load_boundaries
         self.temporal_options = temporal_options
         self.num_samples = num_samples
+        self.swap_order = swap_order
 
         if self.load_boundaries:
             print("Loading 3 Class Masks, with Boundaries")
@@ -92,6 +95,10 @@ class FTW(NonGeoDataset):
             print("Loading 2 Class Masks, without Boundaries")
 
         print("Temporal option: ", temporal_options)
+        if swap_order:
+            print("Using window A first, then window B")
+        else:
+            print("Using window B first, then window A")
 
         if not self._check_integrity():
             raise RuntimeError(
@@ -274,6 +281,9 @@ class FTW(NonGeoDataset):
                 if self.temporal_options == "rgb":  # select 3 channels only
                     window_a_img = window_a_img[:3]
                 images.append(window_a_img)
+
+        if self.swap_order and len(images) == 2:
+            images = [images[1], images[0]]
 
         if self.temporal_options == "median":
             images = np.array(images).astype(np.int32)

--- a/ftw_tools/torchgeo/datasets.py
+++ b/ftw_tools/torchgeo/datasets.py
@@ -327,7 +327,7 @@ class FTW(NonGeoDataset):
             )
             img2 = img2.numpy().transpose(1, 2, 0)
 
-        mask = sample["mask"].numpy()
+        mask = sample["mask"].numpy().squeeze()
         num_panels = 3 if self.temporal_options in ("stacked", "rgb") else 2
         if "prediction" in sample:
             num_panels += 1

--- a/ftw_tools/torchgeo/trainers.py
+++ b/ftw_tools/torchgeo/trainers.py
@@ -254,7 +254,7 @@ class CustomSemanticSegmentationTask(BaseTask):
             The loss tensor.
         """
         x = batch["image"]
-        y = batch["mask"]
+        y = batch["mask"].squeeze(1)
         y_hat = self(x)
         loss: Tensor = self.criterion(y_hat, y)
         self.log("train_loss", loss)
@@ -273,7 +273,7 @@ class CustomSemanticSegmentationTask(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch["image"]
-        y = batch["mask"]
+        y = batch["mask"].squeeze(1)
         y_hat = self(x)
         loss: Tensor = self.criterion(y_hat, y)
         self.log("val_loss", loss)
@@ -322,7 +322,7 @@ class CustomSemanticSegmentationTask(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch["image"]
-        y = batch["mask"]
+        y = batch["mask"].squeeze(1)
         y_hat = self(x)
         loss: Tensor = self.criterion(y_hat, y)
         self.log("test_loss", loss)

--- a/ftw_tools/torchgeo/trainers.py
+++ b/ftw_tools/torchgeo/trainers.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Union
 
 import lightning
 import matplotlib.pyplot as plt
+import numpy as np
 import segmentation_models_pytorch as smp
 import torch
 import torch.nn as nn
@@ -17,8 +18,15 @@ from torchgeo.datasets import unbind_samples
 from torchgeo.models import FCN
 from torchgeo.trainers.base import BaseTask
 from torchmetrics import MetricCollection
-from torchmetrics.classification import MulticlassAccuracy, MulticlassJaccardIndex
+from torchmetrics.classification import (
+    MulticlassAccuracy,
+    MulticlassJaccardIndex,
+    MulticlassPrecision,
+    MulticlassRecall,
+)
 from torchvision.models._api import WeightsEnum
+
+from ..postprocess.metrics import get_object_level_metrics
 
 
 class CustomSemanticSegmentationTask(BaseTask):
@@ -103,7 +111,7 @@ class CustomSemanticSegmentationTask(BaseTask):
                 "ignore_index has no effect on training when loss='jaccard'",
                 UserWarning,
             )
-
+        self.class_names = ["background", "field", "boundary"]
         self.weights = weights
         super().__init__()
         print(self.hparams)
@@ -146,22 +154,40 @@ class CustomSemanticSegmentationTask(BaseTask):
         """Initialize the performance metrics."""
         num_classes: int = self.hparams["num_classes"]
         ignore_index: Optional[int] = self.hparams["ignore_index"]
-        metrics = MetricCollection(
-            [
-                MulticlassAccuracy(
-                    num_classes=num_classes,
-                    ignore_index=ignore_index,
-                    multidim_average="global",
-                    average="micro",
+
+        base_metrics = {
+            "precision": MulticlassPrecision(
+                num_classes, average=None, ignore_index=ignore_index
+            ),
+            "recall": MulticlassRecall(
+                num_classes, average=None, ignore_index=ignore_index
+            ),
+            "iou": MulticlassJaccardIndex(
+                num_classes, average=None, ignore_index=ignore_index
+            ),
+        }
+        self.train_metrics = MetricCollection(base_metrics, prefix="train/")
+        self.val_metrics = self.train_metrics.clone(prefix="val/")
+        self.test_metrics = self.train_metrics.clone(prefix="test/")
+
+        self.val_agg = MetricCollection(
+            {
+                "precision_macro": MulticlassPrecision(
+                    num_classes, average="macro", ignore_index=ignore_index
                 ),
-                MulticlassJaccardIndex(
-                    num_classes=num_classes, ignore_index=ignore_index, average="micro"
+                "recall_macro": MulticlassRecall(
+                    num_classes, average="macro", ignore_index=ignore_index
                 ),
-            ]
+                "iou_macro": MulticlassJaccardIndex(
+                    num_classes, average="macro", ignore_index=ignore_index
+                ),
+            },
+            prefix="val/",
         )
-        self.train_metrics = metrics.clone(prefix="train_")
-        self.val_metrics = metrics.clone(prefix="val_")
-        self.test_metrics = metrics.clone(prefix="test_")
+
+        self.val_tps = 0
+        self.val_fps = 0
+        self.val_fns = 0
 
     def configure_models(self) -> None:
         """Initialize the model.
@@ -240,6 +266,22 @@ class CustomSemanticSegmentationTask(BaseTask):
         if patch_weights:
             self.transfer_weights(self.model, backbone)
 
+    def _log_per_class(self, metrics_dict, split: str):
+        # metrics_dict like {"precision": tensor(C,), "recall": tensor(C,), "iou": tensor(C,)}
+        for name, values in metrics_dict.items():
+            # values is shape [C]
+            for i, v in enumerate(values):
+                cname = self.class_names[i]
+                if cname == "field":
+                    self.log(
+                        f"{name}/{cname}",
+                        v,
+                        on_step=False,
+                        on_epoch=True,
+                        prog_bar=False,
+                        sync_dist=True,
+                    )
+
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
@@ -257,9 +299,17 @@ class CustomSemanticSegmentationTask(BaseTask):
         y = batch["mask"].squeeze(1)
         y_hat = self(x)
         loss: Tensor = self.criterion(y_hat, y)
-        self.log("train_loss", loss)
-        self.train_metrics(y_hat, y)
-        self.log_dict(self.train_metrics)
+
+        self.log(
+            "train/loss",
+            loss,
+            on_step=True,
+            on_epoch=True,
+            prog_bar=True,
+            sync_dist=True,
+        )
+        self.train_metrics.update(y_hat, y)
+
         return loss
 
     def validation_step(
@@ -276,9 +326,25 @@ class CustomSemanticSegmentationTask(BaseTask):
         y = batch["mask"].squeeze(1)
         y_hat = self(x)
         loss: Tensor = self.criterion(y_hat, y)
-        self.log("val_loss", loss)
-        self.val_metrics(y_hat, y)
-        self.log_dict(self.val_metrics)
+
+        for i in range(y_hat.shape[0]):
+            output = y_hat[i].argmax(dim=0).cpu().numpy().astype(np.uint8)
+            mask = y[i].cpu().numpy().astype(np.uint8)
+            tps, fps, fns = get_object_level_metrics(mask, output, iou_threshold=0.5)
+            self.val_tps += tps
+            self.val_fps += fps
+            self.val_fns += fns
+
+        self.log(
+            "val/loss",
+            loss,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            sync_dist=True,
+        )
+        self.val_metrics.update(y_hat, y)
+        self.val_agg.update(y_hat, y)
 
         if (
             batch_idx < 10
@@ -326,25 +392,7 @@ class CustomSemanticSegmentationTask(BaseTask):
         y_hat = self(x)
         loss: Tensor = self.criterion(y_hat, y)
         self.log("test_loss", loss)
-        self.test_metrics(y_hat, y)
-        self.log_dict(self.test_metrics)
-
-    def predict_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
-    ) -> Tensor:
-        """Compute the predicted class probabilities.
-
-        Args:
-            batch: The output of your DataLoader.
-            batch_idx: Integer displaying index of this batch.
-            dataloader_idx: Index of the current dataloader.
-
-        Returns:
-            Output predicted probabilities.
-        """
-        x = batch["image"]
-        y_hat: Tensor = self(x).softmax(dim=1)
-        return y_hat
+        self.test_metrics.update(y_hat, y)
 
     def configure_optimizers(
         self,
@@ -366,6 +414,49 @@ class CustomSemanticSegmentationTask(BaseTask):
     def on_train_epoch_start(self) -> None:
         lr = self.optimizers().param_groups[0]["lr"]
         self.logger.experiment.add_scalar("lr", lr, self.current_epoch)
+
+    def on_train_epoch_end(self):
+        computed = self.train_metrics.compute()
+        self._log_per_class(computed, "train")
+        self.train_metrics.reset()
+
+    def on_validation_epoch_end(self) -> None:
+        object_precision = (
+            self.val_tps / (self.val_tps + self.val_fps)
+            if (self.val_tps + self.val_fps) > 0
+            else 0
+        )
+        object_recall = (
+            self.val_tps / (self.val_tps + self.val_fns)
+            if (self.val_tps + self.val_fns) > 0
+            else 0
+        )
+        object_f1 = (
+            2 * object_precision * object_recall / (object_precision + object_recall)
+            if (object_precision + object_recall) > 0
+            else 0
+        )
+        self.log("val/object_precision", object_precision)
+        self.log("val/object_recall", object_recall)
+        self.log("val/object_f1", object_f1)
+
+        self.val_tps = 0
+        self.val_fps = 0
+        self.val_fns = 0
+
+        per_class = self.val_metrics.compute()
+        self._log_per_class(per_class, "val")
+        self.val_metrics.reset()
+
+        # log aggregates (single scalars)
+        agg = self.val_agg.compute()
+        self.log_dict(agg, on_step=False, on_epoch=True, sync_dist=True)
+        self.val_agg.reset()
+
+    def on_test_epoch_end(self):
+        per_class = self.test_metrics.compute()
+        self._log_per_class(per_class, "test")
+        self.test_metrics.reset()
 
     def transfer_weights(self, model, backbone):
         base_model = None


### PR DESCRIPTION
This PR turned into a fix-everything wrong I found while running experiments.

Changes:
- Divorced from torchgeo's NonGeoDataModule
- Added a feature to the FTW dataset for flipping the order of win_a and win_b
- Added a flag to the evaluation script that flips the order of win_a and win_b
- Added a feature to the DataModule for randomly flipping win_a and win_b per batch
- Added a feature to the DataModule for resizing everything by a factor
- Fixed the result output formatting in the eval script 
- Made the trainer log things that are actually useful to monitor