### PR TITLE
--postprocess never worked

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -166,7 +166,6 @@ Options:
   --dir TEXT                  Root directory of dataset
   --gpu INTEGER               GPU to use
   --countries TEXT            Countries to evaluate on  [required]
-  --postprocess               Apply postprocessing to the model output
   --iou_threshold FLOAT       IoU threshold for matching predictions to ground
                               truths
  -o, --out TEXT               Output file for metrics
@@ -180,7 +179,7 @@ Options:
 
 ### Test a model
 
-Using FTW cli commands to test the model, you can pass specific options, such as selecting the GPUs, providing checkpoints, specifying countries for testing, and postprocessing results:
+Using FTW cli commands to test the model, you can pass specific options, such as selecting the GPUs, providing checkpoints, and specifying countries for testing:
 
 ```bash
 ftw model test --gpu 0 --dir /path/to/dataset --model logs/path_to_model/checkpoints/last.ckpt --countries country_to_test_on --out results.csv

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -175,14 +175,6 @@ def model_fit(config, ckpt_path, cli_args):
     help="GPU to use, zero-based index. Set to -1 to use CPU. CPU is also always used if CUDA is not available.",
 )
 @click.option(
-    "--postprocess",
-    "-pp",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="Apply postprocessing to the model output",
-)
-@click.option(
     "--iou_threshold",
     "-iou",
     type=click.FloatRange(min=0.0, max=1.0),
@@ -227,7 +219,6 @@ def model_test(
     countries,
     dir,
     gpu,
-    postprocess,
     iou_threshold,
     out,
     model_predicts_3_classes,
@@ -241,7 +232,6 @@ def model_test(
         dir,
         gpu,
         countries,
-        postprocess,
         iou_threshold,
         out,
         model_predicts_3_classes,

--- a/ftw_tools/models/baseline_eval.py
+++ b/ftw_tools/models/baseline_eval.py
@@ -58,7 +58,6 @@ def test(
     dir,
     gpu,
     countries,
-    postprocess,
     iou_threshold,
     out,
     model_predicts_3_classes,
@@ -159,9 +158,6 @@ def test(
         for i in range(len(outputs)):
             output = outputs[i]
             mask = masks[i]
-            if postprocess:
-                post_processed_output = out.copy()
-                output = post_processed_output
             tps, fps, fns = get_object_level_metrics(
                 mask, output, iou_threshold=iou_threshold
             )


### PR DESCRIPTION
We had a flag in `ftw model test` that a.) didn't ever do anything; and b.) runtime errored if you tried to use it. The original idea here was to add some morphological operations to clean up predictions but we should do systematic experiments before implementing something like this.