### PR TITLE
Add option to save logit scores for inference tif

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ Options:
                                   1024x1024px and a smaller value otherwise.
                                   [x>=0]
   -mps, --mps_mode                Run inference in MPS mode (Apple GPUs).
-  --save_scores                   Save segmentation logit scores instead of
-                                  classes (argmax of scores)
+  --save_scores                   Save segmentation softmax scores (rescaled to [0,255])
+                                  instead of classes (argmax of scores)
   -h, --stac_host [mspc|earthsearch]
                                   The host to download the imagery from. mspc
                                   = Microsoft Planetary Computer, earthsearch
@@ -375,8 +375,8 @@ Options:
                                   [x>=0]
   -f, --overwrite                 Overwrite outputs if they exist.
   -mps, --mps_mode                Run inference in MPS mode (Apple GPUs).
-  --save_scores                   Save segmentation logit scores instead of
-                                  classes (argmax of scores)
+  --save_scores                   Save segmentation softmax scores (rescaled to [0,255])
+                                  instead of classes (argmax of scores)
   --help                          Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -208,33 +208,63 @@ ftw inference all --help
 
 Usage: ftw inference all [OPTIONS]
 
-  Run all inference commands from crop calendar scene selection, then
-  download, inference and polygonize.
+  Run all inference commands from crop calendar scene selection,then download,
+  inference and polygonize.
 
 Options:
-  --bbox TEXT              Bounding box to use for the download in the format
-                           'minx,miny,maxx,maxy'
-  --year INTEGER           Year to run model inference over  [required]
-  --cloud_cover_max INTEGER
-                           Max percent cloud cover in sentinel2 scene
-                           [default: 20]
-  --buffer_days INTEGER    Number of days to buffer the date for querying to
-                           help balance decreasing cloud cover and selecting a
-                           date near the crop calendar indicated date.
-                           [default: 14]
-  -o, --out TEXT           Directory to save downloaded inference imagery, and
-                           inference output to  [required]
-  -f, --overwrite          Overwrites the outputs if they exist
-  -m, --model PATH         Path to the model checkpoint.  [required]
-  --resize_factor INTEGER  Resize factor to use for inference.  [default: 2]
-  --gpu INTEGER            GPU ID to use. If not provided, CPU will be used by
-                           default.
-  --patch_size INTEGER     Size of patch to use for inference. Defaults to
-                           1024 unless the image is < 1024x1024px.
-  --batch_size INTEGER     Batch size.  [default: 2]
-  --padding INTEGER        Pixels to discard from each side of the patch.
-  --mps_mode               Run inference in MPS mode (Apple GPUs).
-  --help                   Show this message and exit.
+  -o, --out PATH                  Directory to save downloaded inference
+                                  imagery, and inference output to  [required]
+  -m, --model PATH                Path to the model checkpoint.  [required]
+  --year INTEGER RANGE            Year to run model inference over
+                                  [2015<=x<=2025; required]
+  --bbox TEXT                     Bounding box to use for the download in the
+                                  format 'minx,miny,maxx,maxy'
+  -ccx, --cloud_cover_max INTEGER RANGE
+                                  Maximum percentage of cloud cover allowed in
+                                  the Sentinel-2 scene  [default: 20;
+                                  0<=x<=100]
+  -b, --buffer_days INTEGER RANGE
+                                  Number of days to buffer the date for
+                                  querying to help balance decreasing cloud
+                                  cover and selecting a date near the crop
+                                  calendar indicated date.  [default: 14;
+                                  x>=0]
+  -f, --overwrite                 Overwrites the outputs if they exist
+  -r, --resize_factor INTEGER RANGE
+                                  Resize factor to use for inference.
+                                  [default: 2; x>=1]
+  --gpu INTEGER                   GPU to use, zero-based index. Set to -1 to
+                                  use CPU. CPU is also always used if CUDA or
+                                  MPS is not available.  [default: -1]
+  -ps, --patch_size INTEGER RANGE
+                                  Size of patch to use for inference. Defaults
+                                  to 1024 unless the image is < 1024x1024px
+                                  and a smaller value otherwise.  [x>=128]
+  -bs, --batch_size INTEGER RANGE
+                                  Batch size.  [default: 2; x>=1]
+  --num_workers INTEGER RANGE     Number of workers to use for inference.
+                                  [default: 4; x>=1]
+  -p, --padding INTEGER RANGE     Pixels to discard from each side of the
+                                  patch. Defaults to 64 unless the image is <
+                                  1024x1024px and a smaller value otherwise.
+                                  [x>=0]
+  -mps, --mps_mode                Run inference in MPS mode (Apple GPUs).
+  --save_scores                   Save segmentation logit scores instead of
+                                  classes (argmax of scores)
+  -h, --stac_host [mspc|earthsearch]
+                                  The host to download the imagery from. mspc
+                                  = Microsoft Planetary Computer, earthsearch
+                                  = EarthSearch (Element84/AWS).  [default:
+                                  mspc]
+  -s2, --s2_collection [old-baseline|c1]
+                                  Sentinel-2 collection to use with
+                                  EarthSearch only: 'old-baseline' =
+                                  sentinel-2-l2a, 'c1' = sentinel-2-c1-l2a
+                                  (default). Ignored when using MSPC.
+                                  [default: c1]
+  -v, --verbose                   Enable verbose output showing STAC calls,
+                                  scene details, and download URLs.
+  --help                          Show this message and exit.
 ```
 
 Example usage:
@@ -321,19 +351,33 @@ Usage: ftw inference run [OPTIONS] INPUT
   INPUT.
 
 Options:
-  -m, --model PATH         Path to the model checkpoint.  [required]
-  -o, --out TEXT           Output filename.  [required]
-  --resize_factor INTEGER  Resize factor to use for inference.  [default: 2]
-  --gpu INTEGER            GPU ID to use. If not provided, CPU will be used by
-                           default.
-  --patch_size INTEGER     Size of patch to use for inference. Defaults to
-                           1024 unless the image is < 1024x1024px.
-  --batch_size INTEGER     Batch size.  [default: 2]
-  --padding INTEGER        Pixels to discard from each side of the patch.
-                           Defaults to 64 unless the image is < 1024x1024px.
-  -f, --overwrite          Overwrite outputs if they exist.
-  --mps_mode               Run inference in MPS mode (Apple GPUs).
-  --help                   Show this message and exit.
+  -m, --model PATH                Path to the model checkpoint.  [required]
+  -o, --out PATH                  Output filename for the inference imagery.
+                                  Defaults to the name of the input file name
+                                  with 'inference.' prefix.
+  -r, --resize_factor INTEGER RANGE
+                                  Resize factor to use for inference.
+                                  [default: 2; x>=1]
+  --gpu INTEGER                   GPU to use, zero-based index. Set to -1 to
+                                  use CPU. CPU is also always used if CUDA or
+                                  MPS is not available.  [default: -1]
+  -ps, --patch_size INTEGER RANGE
+                                  Size of patch to use for inference. Defaults
+                                  to 1024 unless the image is < 1024x1024px
+                                  and a smaller value otherwise.  [x>=128]
+  -bs, --batch_size INTEGER RANGE
+                                  Batch size.  [default: 2; x>=1]
+  --num_workers INTEGER RANGE     Number of workers to use for inference.
+                                  [default: 4; x>=1]
+  -p, --padding INTEGER RANGE     Pixels to discard from each side of the
+                                  patch. Defaults to 64 unless the image is <
+                                  1024x1024px and a smaller value otherwise.
+                                  [x>=0]
+  -f, --overwrite                 Overwrite outputs if they exist.
+  -mps, --mps_mode                Run inference in MPS mode (Apple GPUs).
+  --save_scores                   Save segmentation logit scores instead of
+                                  classes (argmax of scores)
+  --help                          Show this message and exit.
 ```
 
 Let's run inference on the entire downloaded scene.

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -457,6 +457,13 @@ def inference():
     show_default=True,
     help="Run inference in MPS mode (Apple GPUs).",
 )
+@click.option(
+    "--save_scores",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Save segmentation logit scores instead of classes (argmax of scores)",
+)
 @common_stac_host_option()
 @common_s2_collection_option()
 @common_verbose_option()
@@ -475,6 +482,7 @@ def ftw_inference_all(
     num_workers,
     padding,
     mps_mode,
+    save_scores,
     stac_host,
     s2_collection,
     verbose,
@@ -528,6 +536,7 @@ def ftw_inference_all(
         padding=padding,
         overwrite=overwrite,
         mps_mode=mps_mode,
+        save_scores=save_scores,
     )
 
     # Polygonize the output
@@ -704,6 +713,13 @@ def inference_download(
     show_default=True,
     help="Run inference in MPS mode (Apple GPUs).",
 )
+@click.option(
+    "--save_scores",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Save segmentation logit scores instead of classes (argmax of scores)",
+)
 def inference_run(
     input,
     model,
@@ -716,6 +732,7 @@ def inference_run(
     padding,
     overwrite,
     mps_mode,
+    save_scores,
 ):
     from ftw_tools.models.baseline_inference import run
 
@@ -731,6 +748,7 @@ def inference_run(
         padding,
         overwrite,
         mps_mode,
+        save_scores,
     )
 
 

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -462,7 +462,7 @@ def inference():
     is_flag=True,
     default=False,
     show_default=True,
-    help="Save segmentation logit scores instead of classes (argmax of scores)",
+    help="Save segmentation softmax scores (rescaled to [0,255]) instead of classes (argmax of scores)",
 )
 @common_stac_host_option()
 @common_s2_collection_option()
@@ -718,7 +718,7 @@ def inference_download(
     is_flag=True,
     default=False,
     show_default=True,
-    help="Save segmentation logit scores instead of classes (argmax of scores)",
+    help="Save segmentation softmax scores (rescaled to [0,255]) instead of classes (argmax of scores)",
 )
 def inference_run(
     input,


### PR DESCRIPTION
Currently the CLI only has the option to save the segmentation class output (3 classes, 1 channel output raster). 

I want the option to save the raw logit prediction scores before the argmax is applied to get the predicted class in each pixel (3 classes, 3 channel output raster). For example, the scores are needed to use Lyndon Estes' [instancemaker](https://github.com/agroimpacts/instancemaker) library for fancier polygonizing than we have in the repo currently. 

This PR adds the command line option `--save_scores` which saves the prediction scores instead of the classes. 

Example output for Austria:
```ftw inference all \                                              
    --bbox=13.0,48.0,13.2,48.2 \
    --year=2024 \
    --out=test-austria-all \
    --cloud_cover_max=20 \
    --buffer_days=14 \
    --model=model-ckpts/3_Class_FULL_FTW_Pretrained.ckpt \
    --resize_factor=2 \
    --overwrite \
    --save_scores
```
<img width="454" height="651" alt="image" src="https://github.com/user-attachments/assets/daaefbb5-37f0-47c7-9423-5ef922ec822f" />

```ftw inference all \                                              
    --bbox=13.0,48.0,13.2,48.2 \
    --year=2024 \
    --out=test-austria-all \
    --cloud_cover_max=20 \
    --buffer_days=14 \
    --model=model-ckpts/3_Class_FULL_FTW_Pretrained.ckpt \
    --resize_factor=2 \
    --overwrite
```
<img width="454" height="651" alt="image" src="https://github.com/user-attachments/assets/8c617798-468f-4cbb-8ed3-679d23151126" />

Note: I think the stripes on the sides are due to [this issue](https://github.com/fieldsoftheworld/ftw-inference-app/issues/73) which @calebrob6 addressed in #166