### PR TITLE
fix: crop calendar tiffs missing in pypi install

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,6 +11,16 @@ jobs:
     env:
       CONDA_OVERRIDE_CUDA: 12.0
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.10
         with:
@@ -39,6 +49,17 @@ jobs:
     env:
       CONDA_OVERRIDE_CUDA: 12.0
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.10
         with:
@@ -70,6 +91,17 @@ jobs:
     env:
       CONDA_OVERRIDE_CUDA: 12.0
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.10
         with:

--- a/ftw_tools/download/crop_calendar.py
+++ b/ftw_tools/download/crop_calendar.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+
+import wget
+
+CROP_CALENDAR_BASE_URL = "https://github.com/fieldsoftheworld/ftw-baselines/raw/main/assets/global_crop_calendar/"
+CROP_CALENDAR_FILES = [
+    "sc_sos_3x3_v2_cog.tiff",
+    "sc_eos_3x3_v2_cog.tiff",
+]
+
+
+def get_crop_calendar_cache_dir() -> Path:
+    """Get the cache directory for crop calendar files.
+
+    Returns:
+        The cache directory path for crop calendar files.
+    """
+    cache_base = os.environ.get("FTW_CACHE_DIR")
+    if not cache_base:
+        cache_base = Path.home() / ".cache" / "ftw-tools"
+    else:
+        cache_base = Path(cache_base)
+
+    cache_dir = cache_base / "crop_calendar"
+    return cache_dir
+
+
+def ensure_crop_calendar_exists() -> Path:
+    """Ensure crop calendar files exist, downloading if necessary.
+
+    Returns:
+        The cache directory containing the crop calendar files.
+    """
+    cache_dir = get_crop_calendar_cache_dir()
+
+    all_files_exist = cache_dir.exists() and all(
+        (cache_dir / filename).exists() for filename in CROP_CALENDAR_FILES
+    )
+
+    if not all_files_exist:
+        print("Downloading crop calendar files (first-time setup)...")
+        success = download_crop_calendar_files()
+        if not success:
+            raise RuntimeError("Failed to download crop calendar files")
+
+    return cache_dir
+
+
+def download_crop_calendar_files(force: bool = False) -> bool:
+    """Download all crop calendar files.
+
+    Args:
+        force: If True, re-download even if files exist.
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    cache_dir = get_crop_calendar_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        for filename in CROP_CALENDAR_FILES:
+            file_path = cache_dir / filename
+
+            if file_path.exists() and not force:
+                continue
+
+            url = CROP_CALENDAR_BASE_URL + filename
+            print(f"Downloading {filename}...")
+
+            if file_path.exists():
+                file_path.unlink()
+
+            wget.download(url, str(file_path.resolve()))
+
+        print(f"Files cached at {cache_dir}")
+        return True
+
+    except Exception as e:
+        print(f"Error downloading crop calendar files: {e}")
+        return False

--- a/ftw_tools/download/crop_calendar.py
+++ b/ftw_tools/download/crop_calendar.py
@@ -3,11 +3,7 @@ from pathlib import Path
 
 import wget
 
-CROP_CALENDAR_BASE_URL = "https://github.com/fieldsoftheworld/ftw-baselines/raw/main/assets/global_crop_calendar/"
-CROP_CALENDAR_FILES = [
-    "sc_sos_3x3_v2_cog.tiff",
-    "sc_eos_3x3_v2_cog.tiff",
-]
+from ftw_tools.settings import CROP_CALENDAR_BASE_URL, CROP_CALENDAR_FILES
 
 
 def get_crop_calendar_cache_dir() -> Path:

--- a/ftw_tools/download/crop_calendar.py
+++ b/ftw_tools/download/crop_calendar.py
@@ -36,43 +36,32 @@ def ensure_crop_calendar_exists() -> Path:
 
     if not all_files_exist:
         print("Downloading crop calendar files (first-time setup)...")
-        success = download_crop_calendar_files()
-        if not success:
-            raise RuntimeError("Failed to download crop calendar files")
+        download_crop_calendar_files()
 
     return cache_dir
 
 
-def download_crop_calendar_files(force: bool = False) -> bool:
+def download_crop_calendar_files(force: bool = False) -> None:
     """Download all crop calendar files.
 
     Args:
         force: If True, re-download even if files exist.
-
-    Returns:
-        True if successful, False otherwise.
     """
     cache_dir = get_crop_calendar_cache_dir()
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        for filename in CROP_CALENDAR_FILES:
-            file_path = cache_dir / filename
+    for filename in CROP_CALENDAR_FILES:
+        file_path = cache_dir / filename
 
-            if file_path.exists() and not force:
-                continue
+        if file_path.exists() and not force:
+            continue
 
-            url = CROP_CALENDAR_BASE_URL + filename
-            print(f"Downloading {filename}...")
+        url = CROP_CALENDAR_BASE_URL + filename
+        print(f"Downloading {filename}...")
 
-            if file_path.exists():
-                file_path.unlink()
+        if file_path.exists():
+            file_path.unlink()
 
-            wget.download(url, str(file_path.resolve()))
+        wget.download(url, str(file_path.resolve()))
 
-        print(f"Files cached at {cache_dir}")
-        return True
-
-    except Exception as e:
-        print(f"Error downloading crop calendar files: {e}")
-        return False
+    print(f"Files cached at {cache_dir}")

--- a/ftw_tools/models/baseline_inference.py
+++ b/ftw_tools/models/baseline_inference.py
@@ -283,9 +283,10 @@ def run_instance_segmentation(
     """
     from .delineate_anything import DelineateAnything
 
-    assert model in ["DelineateAnything", "DelineateAnything-S"], (
-        "Model must be either DelineateAnything or DelineateAnything-S."
-    )
+    assert model in [
+        "DelineateAnything",
+        "DelineateAnything-S",
+    ], "Model must be either DelineateAnything or DelineateAnything-S."
 
     padding = padding if padding is not None else patch_size // 4
     device, _, _, patch_size, stride, _ = setup_inference(

--- a/ftw_tools/settings.py
+++ b/ftw_tools/settings.py
@@ -13,7 +13,13 @@ MSPC_BANDS_OF_INTEREST = ["B04", "B03", "B02", "B08"]
 EARTHSEARCH_URL = "https://earth-search.aws.element84.com/v1"
 
 # Supported file formats for the inference polygon command
-SUPPORTED_POLY_FORMATS_TXT = "Available file extensions: .parquet (GeoParquet, fiboa-compliant), .fgb (FlatGeoBuf), .gpkg (GeoPackage), .geojson / .json / .ndjson (GeoJSON)"
+SUPPORTED_POLY_FORMATS_TXT = (
+    "Available file extensions: "
+    ".parquet (GeoParquet, fiboa-compliant), "
+    ".fgb (FlatGeoBuf), "
+    ".gpkg (GeoPackage), "
+    ".geojson / .json / .ndjson (GeoJSON)"
+)
 
 # List of all available countries
 ALL_COUNTRIES = [
@@ -56,4 +62,16 @@ TEMPORAL_OPTIONS = [
 LULC_COLLECTIONS = [
     "io-lulc-annual-v02",
     "esa-worldcover",
+]
+
+# Crop Calendar Configuration
+CROP_CALENDAR_BASE_URL = (
+    "https://data.source.coop/ftw/ftw-inference-input/global-crop-calendar/"
+)
+
+CROP_CALENDAR_FILES = [
+    CROP_CAL_SUMMER_START := "sc-sos-3x3-v2-cog.tiff",
+    CROP_CAL_SUMMER_END := "sc-eos-3x3-v2-cog.tiff",
+    CROP_CAL_WINTER_START := "wc-sos-3x3-v2-cog.tiff",
+    CROP_CAL_WINTER_END := "wc-eos-3x3-v2-cog.tiff",
 ]

--- a/ftw_tools/utils.py
+++ b/ftw_tools/utils.py
@@ -9,6 +9,7 @@ import scipy.stats
 import xarray as xr
 
 from ftw_tools.download.crop_calendar import ensure_crop_calendar_exists
+from ftw_tools.settings import CROP_CAL_SUMMER_END, CROP_CAL_SUMMER_START
 
 logger = logging.getLogger()
 
@@ -95,10 +96,10 @@ def get_harvest_integer_from_bbox(
 
     if start_year_raster_path is None:
         cache_dir = ensure_crop_calendar_exists()
-        start_year_raster_path = str(cache_dir / "sc_sos_3x3_v2_cog.tiff")
+        start_year_raster_path = str(cache_dir / CROP_CAL_SUMMER_START)
     if end_year_raster_path is None:
         cache_dir = ensure_crop_calendar_exists()
-        end_year_raster_path = str(cache_dir / "sc_eos_3x3_v2_cog.tiff")
+        end_year_raster_path = str(cache_dir / CROP_CAL_SUMMER_END)
 
     start_harvest_dset = xr.open_dataset(start_year_raster_path, engine="rasterio")
     end_harvest_dset = xr.open_dataset(end_year_raster_path, engine="rasterio")

--- a/ftw_tools/utils.py
+++ b/ftw_tools/utils.py
@@ -8,15 +8,20 @@ import scipy
 import scipy.stats
 import xarray as xr
 
-# Harvest day raster paths from https://github.com/ucg-uv/research_products/tree/main
-SUMMER_START_RASTER_PATH = "assets/global_crop_calendar/sc_sos_3x3_v2_cog.tiff"
-SUMMER_END_RASTER_PATH = "assets/global_crop_calendar/sc_eos_3x3_v2_cog.tiff"
+from ftw_tools.download.crop_calendar import ensure_crop_calendar_exists
 
 logger = logging.getLogger()
 
 
-def compute_md5(file_path):
-    """Compute the MD5 checksum of a file."""
+def compute_md5(file_path: str) -> str | None:
+    """Compute the MD5 checksum of a file.
+
+    Args:
+        file_path: Path to the file to compute checksum for.
+
+    Returns:
+        The MD5 checksum as a hexadecimal string, or None if file not found.
+    """
     hash_md5 = hashlib.md5()
     try:
         with open(file_path, "rb") as f:
@@ -27,11 +32,19 @@ def compute_md5(file_path):
     return hash_md5.hexdigest()
 
 
-def validate_checksums(checksum_file, root_directory):
-    """Validate checksums stored in a checksum file."""
+def validate_checksums(checksum_file: str, root_directory: str) -> bool:
+    """Validate checksums stored in a checksum file.
+
+    Args:
+        checksum_file: Path to the checksum file.
+        root_directory: Root directory for resolving relative file paths.
+
+    Returns:
+        True if all checksums match, False otherwise.
+    """
     if not os.path.isfile(checksum_file):
         print(f"Checksum file not found: {checksum_file}")
-        return
+        return False
 
     with open(checksum_file, "r") as f:
         lines = f.readlines()
@@ -52,34 +65,40 @@ def validate_checksums(checksum_file, root_directory):
 
 
 def harvest_to_datetime(harvest_day: int, year: int) -> pd.Timestamp:
-    """
-    Convert a harvest integer (day of the year) to a datetime object.
+    """Convert a harvest integer (day of the year) to a datetime object.
 
     Args:
-        harvest_day (int): Day of the year (1-365).
-        year (int): The year for which the date is to be calculated.
+        harvest_day: Day of the year (1-365).
+        year: The year for which the date is to be calculated.
 
     Returns:
-        pd.Timestamp: Corresponding datetime object.
+        Corresponding datetime object.
     """
     return pd.to_datetime(f"{year}-{harvest_day}", format="%Y-%j")
 
 
-# to-do func to get harvest integer from user provided bbox
 def get_harvest_integer_from_bbox(
     bbox: list[float],
-    start_year_raster_path: str = SUMMER_START_RASTER_PATH,
-    end_year_raster_path: str = SUMMER_END_RASTER_PATH,
+    start_year_raster_path: str = None,
+    end_year_raster_path: str = None,
 ) -> list[int]:
-    """
-    Gets harvest integer from a user-provided bounding box. Note currently just uses summer crops.
+    """Gets harvest integer from a user-provided bounding box. Note currently just uses summer crops.
 
     Args:
-        bbox (str): Bounding box in the format 'minx,miny,maxx,maxy'.
+        bbox: Bounding box in the format [minx, miny, maxx, maxy].
+        start_year_raster_path: Optional path to start of year raster.
+        end_year_raster_path: Optional path to end of year raster.
 
     Returns:
-        list: start and end harvest integer (day of the year).
+        Start and end harvest integer (day of the year).
     """
+
+    if start_year_raster_path is None:
+        cache_dir = ensure_crop_calendar_exists()
+        start_year_raster_path = str(cache_dir / "sc_sos_3x3_v2_cog.tiff")
+    if end_year_raster_path is None:
+        cache_dir = ensure_crop_calendar_exists()
+        end_year_raster_path = str(cache_dir / "sc_eos_3x3_v2_cog.tiff")
 
     start_harvest_dset = xr.open_dataset(start_year_raster_path, engine="rasterio")
     end_harvest_dset = xr.open_dataset(end_year_raster_path, engine="rasterio")
@@ -114,7 +133,22 @@ def get_harvest_integer_from_bbox(
     return [start_value, end_value]
 
 
-def parse_bbox(ctx, param, value):
+def parse_bbox(
+    ctx: click.Context, param: click.Parameter, value: str | None
+) -> list[float] | None:
+    """Parse and validate a bounding box string.
+
+    Args:
+        ctx: Click context (unused but required for callback).
+        param: Click parameter (unused but required for callback).
+        value: Bounding box string in format 'minx,miny,maxx,maxy'.
+
+    Returns:
+        List of four float values [minx, miny, maxx, maxy], or None if value is None.
+
+    Raises:
+        click.BadParameter: If the bounding box format is invalid.
+    """
     if value is None:
         return None
     if not isinstance(value, str):

--- a/tests/test_crop_calendar.py
+++ b/tests/test_crop_calendar.py
@@ -38,9 +38,8 @@ def test_crop_calendar_download(temp_cache_dir):
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
 
-    result = download_crop_calendar_files()
+    download_crop_calendar_files()
 
-    assert result is True
     assert cache_dir.exists()
 
     for filename in CROP_CALENDAR_FILES:
@@ -80,9 +79,7 @@ def test_force_redownload_integration(temp_cache_dir):
         for filename in CROP_CALENDAR_FILES
     }
 
-    result = download_crop_calendar_files(force=True)
-
-    assert result is True
+    download_crop_calendar_files(force=True)
 
     for filename in CROP_CALENDAR_FILES:
         new_size = (cache_dir / filename).stat().st_size
@@ -116,6 +113,5 @@ def test_download_crop_calendar_files_failure(mock_wget, temp_cache_dir):
     """Test handling of download failure."""
     mock_wget.side_effect = Exception("Network error")
 
-    result = download_crop_calendar_files()
-
-    assert result is False
+    with pytest.raises(Exception, match="Network error"):
+        download_crop_calendar_files()

--- a/tests/test_crop_calendar.py
+++ b/tests/test_crop_calendar.py
@@ -1,0 +1,121 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ftw_tools.download.crop_calendar import (
+    CROP_CALENDAR_FILES,
+    download_crop_calendar_files,
+    ensure_crop_calendar_exists,
+    get_crop_calendar_cache_dir,
+)
+
+
+# Using flat fixture instead of class to match existing test pattern
+@pytest.fixture
+def temp_cache_dir():
+    """Create a temporary cache directory for testing."""
+    temp_dir = tempfile.mkdtemp()
+    original_cache_dir = os.environ.get("FTW_CACHE_DIR")
+    os.environ["FTW_CACHE_DIR"] = temp_dir
+
+    yield temp_dir
+
+    if original_cache_dir:
+        os.environ["FTW_CACHE_DIR"] = original_cache_dir
+    else:
+        os.environ.pop("FTW_CACHE_DIR", None)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_crop_calendar_download(temp_cache_dir):
+    """Test download of crop calendar files from GitHub."""
+    cache_dir = get_crop_calendar_cache_dir()
+
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+
+    result = download_crop_calendar_files()
+
+    assert result is True
+    assert cache_dir.exists()
+
+    for filename in CROP_CALENDAR_FILES:
+        file_path = cache_dir / filename
+        assert file_path.exists()
+        assert file_path.stat().st_size > 0
+
+
+def test_ensure_crop_calendar_exists_uses_cached_files(temp_cache_dir):
+    """Test that existing files are not re-downloaded."""
+    cache_dir = get_crop_calendar_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename in CROP_CALENDAR_FILES:
+        (cache_dir / filename).touch()
+
+    with patch(
+        "ftw_tools.download.crop_calendar.download_crop_calendar_files"
+    ) as mock_download:
+        result = ensure_crop_calendar_exists()
+
+        mock_download.assert_not_called()
+        assert result == cache_dir
+
+
+def test_force_redownload_integration(temp_cache_dir):
+    """Test that force=True actually re-downloads files."""
+    cache_dir = get_crop_calendar_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename in CROP_CALENDAR_FILES:
+        file_path = cache_dir / filename
+        file_path.write_text("dummy content")
+
+    original_sizes = {
+        filename: (cache_dir / filename).stat().st_size
+        for filename in CROP_CALENDAR_FILES
+    }
+
+    result = download_crop_calendar_files(force=True)
+
+    assert result is True
+
+    for filename in CROP_CALENDAR_FILES:
+        new_size = (cache_dir / filename).stat().st_size
+        assert new_size > original_sizes[filename]
+
+
+def test_get_crop_calendar_cache_dir(temp_cache_dir):
+    """Test cache directory path generation."""
+    cache_dir = get_crop_calendar_cache_dir()
+    assert str(cache_dir).startswith(temp_cache_dir)
+    assert "crop_calendar" in str(cache_dir)
+
+
+def test_custom_cache_directory():
+    """Test using a custom cache directory."""
+    temp_dir = tempfile.mkdtemp()
+    custom_dir = Path(temp_dir) / "custom_cache"
+
+    try:
+        with patch.dict(os.environ, {"FTW_CACHE_DIR": str(custom_dir)}):
+            cache_dir = get_crop_calendar_cache_dir()
+
+            assert str(cache_dir).startswith(str(custom_dir))
+            assert "crop_calendar" in str(cache_dir)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@patch("ftw_tools.download.crop_calendar.wget.download")
+def test_download_crop_calendar_files_failure(mock_wget, temp_cache_dir):
+    """Test handling of download failure."""
+    mock_wget.side_effect = Exception("Network error")
+
+    result = download_crop_calendar_files()
+
+    assert result is False


### PR DESCRIPTION
This PR is to close #168, which I discovered when trying to add scene selection to the API. When installing from pypi, these files are missing. To fix this I added caching functionality for crop calendar files used in scene selection, with automatic download on first use.

**Changes**

- Added `ftw_tools/download/crop_calendar.py`: New module for downloading and caching global crop calendar files from GitHub
  - Downloads files to `~/.cache/ftw-tools/crop_calendar/` (configurable via `FTW_CACHE_DIR`)
  - Automatic download on first use with progress indicators
  - Force re-download option for updates
- Updated `ftw_tools/utils.py`: Modified get_harvest_integer_from_bbox() to use cached crop calendar files instead of requiring local paths
- Added tests: Function based test suite with both integration tests (real downloads) and unit tests (mocked failures)
- Standardized docstrings and type hinting in the files I edited.. 

The crop calendar files are now automatically managed, eliminating the need for users to manually download or manage these dependencies for scene selection functionality.