### PR TITLE
Allow user to set the polygonization_stride

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,21 +425,28 @@ Usage: ftw inference polygonize [OPTIONS] INPUT
   Results are in the CRS of the given raster image.
 
 Options:
-  -o, --out TEXT     Output filename for the polygonized data. If not given
-                     defaults to the name of the input file with parquet
-                     extension. Available file extensions: .parquet
-                     (GeoParquet, fiboa-compliant), .fgb (FlatGeoBuf), .gpkg
-                     (GeoPackage), .geojson and .json (GeoJSON)
-  --simplify FLOAT   Simplification factor to use when polygonizing in the
-                     unit of the CRS, e.g. meters for Sentinel-2 imagery in
-                     UTM. Set to 0 to disable simplification.  [default: 15]
-  --min_size FLOAT   Minimum area size in square meters to include in the
-                     output. Set to 0 to disable.  [default: 500]
-  --max_size FLOAT   Maximum area size in square meters to include in the
-                     output. Disabled by default.
-  -f, --overwrite    Overwrite outputs if they exist.
-  --close_interiors  Remove the interiors holes in the polygons.
-  --help             Show this message and exit.
+  -o, --out PATH               Output filename for the polygonized data.
+                               Defaults to the name of the input file with
+                               '.parquet' file extension. Available file
+                               extensions: .parquet (GeoParquet, fiboa-
+                               compliant), .fgb (FlatGeoBuf), .gpkg
+                               (GeoPackage), .geojson / .json / .ndjson
+                               (GeoJSON)
+  -s, --simplify FLOAT RANGE   Simplification factor to use when polygonizing
+                               in the unit of the CRS, e.g. meters for
+                               Sentinel-2 imagery in UTM. Set to 0 to disable
+                               simplification.  [default: 15; x>=0.0]
+  -sn, --min_size FLOAT RANGE  Minimum area size in square meters to include
+                               in the output. Set to 0 to disable.  [default:
+                               500; x>=0.0]
+  -sx, --max_size FLOAT RANGE  Maximum area size in square meters to include
+                               in the output. Disabled by default.  [x>=0.0]
+  -f, --overwrite              Overwrite output if it exists.
+  --close_interiors            Remove the interiors holes in the polygons.
+  -st, --stride INTEGER RANGE  Stride size (in pixels) for cutting tif into
+                               smaller tiles for polygonizing. Helps avoid OOM
+                               errors.  [default: 2048; x>=0]
+  --help                       Show this message and exit.
 ```
 
 Simplification factor is measured in the units of the coordinate reference system (CRS), and for Sentinel-2 this is meters, so a simplification factor of 15 or 20 is usually sufficient (and recommended, or the vector file will be as large as the raster file).

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -1237,12 +1237,22 @@ def inference_run_instance_segmentation_all(
     show_default=True,
     help="Remove the interiors holes in the polygons.",
 )
+@click.option(
+    "--stride",
+    "-st",
+    type=click.IntRange(min=0),
+    default=2048,
+    show_default=True,
+    help="Stride size (in pixels) for cutting tif into smaller tiles for polygonizing. Helps avoid OOM errors.",
+)
 def inference_polygonize(
-    input, out, simplify, min_size, max_size, overwrite, close_interiors
+    input, out, simplify, min_size, max_size, overwrite, close_interiors, stride
 ):
     from ftw_tools.postprocess.polygonize import polygonize
 
-    polygonize(input, out, simplify, min_size, max_size, overwrite, close_interiors)
+    polygonize(
+        input, out, simplify, min_size, max_size, overwrite, close_interiors, stride
+    )
 
 
 @inference.command(

--- a/ftw_tools/postprocess/polygonize.py
+++ b/ftw_tools/postprocess/polygonize.py
@@ -26,6 +26,7 @@ def polygonize(
     max_size=None,
     overwrite=False,
     close_interiors=False,
+    polygonization_stride=2048,
 ):
     """Polygonize the output from inference."""
 
@@ -66,7 +67,6 @@ def polygonize(
 
         input_height, input_width = src.shape
         mask = (src.read(1) == 1).astype(np.uint8)
-        polygonization_stride = 2048
         total_iterations = math.ceil(input_height / polygonization_stride) * math.ceil(
             input_width / polygonization_stride
         )


### PR DESCRIPTION
Currently, we hardcode the polygonization stride to 2048 as a default window to perform polygonization and avoid OOM errors. However, this can result in undesirable splitting of boundaries at the stride boundaries. Users should be able to change this value if they want to (i.e. make it as large as possible to reduce boundary errors).

See example with stride=32 (`ftw inference polygonize austria-inf.tif -o austria-32.gpkg --stride 32`):
<img width="671" height="586" alt="image" src="https://github.com/user-attachments/assets/b6e8fa51-3f15-4a9a-8ee9-b45c745366b4" />

vs 2048 (`ftw inference polygonize austria-inf.tif -o austria-2048.gpkg`): 
<img width="671" height="586" alt="image" src="https://github.com/user-attachments/assets/1135b1e2-890d-400e-8c5e-6ec6510e050f" />

