### PR TITLE
fix: handle MultiPolygon in close_interiors after erode_dilate

### DIFF
--- a/ftw_tools/postprocess/polygonize.py
+++ b/ftw_tools/postprocess/polygonize.py
@@ -446,7 +446,15 @@ def polygonize(
                                 join_style=shapely.geometry.JOIN_STYLE.mitre,
                             )
                         if close_interiors:
-                            geom = shapely.geometry.Polygon(geom.exterior)
+                            if isinstance(geom, shapely.geometry.MultiPolygon):
+                                geom = shapely.geometry.MultiPolygon(
+                                    [
+                                        shapely.geometry.Polygon(g.exterior)
+                                        for g in geom.geoms
+                                    ]
+                                )
+                            else:
+                                geom = shapely.geometry.Polygon(geom.exterior)
                         if simplify > 0:
                             geom = geom.simplify(simplify)
 


### PR DESCRIPTION
## Fix `close_interiors` crash when `erode_dilate` splits a polygon

### Problem

Using `erode_dilate` together with `close_interiors=True` crashes with:

```
AttributeError: 'MultiPolygon' object has no attribute 'exterior'
```

When the erosion is large enough to sever a narrow connection between two field areas,
Shapely returns a `MultiPolygon` instead of a `Polygon`. The `close_interiors` branch
in `ftw_tools/postprocess/polygonize.py` assumes the geometry is always a simple `Polygon` and calls `.exterior`
directly on it — which doesn't exist on `MultiPolygon`.

```python
# polygonize.py
if close_interiors:
    geom = shapely.geometry.Polygon(geom.exterior)  # breaks if geom is MultiPolygon
```

### Fix

Check the geometry type and apply `close_interiors` to each part individually:

```python
if close_interiors:
    if isinstance(geom, shapely.geometry.MultiPolygon):
        geom = shapely.geometry.MultiPolygon(
            [shapely.geometry.Polygon(p.exterior) for p in geom.geoms]
        )
    else:
        geom = shapely.geometry.Polygon(geom.exterior)
```

### Reproducer

The script below creates a synthetic raster with two blobs joined by a 20m bridge.
`erode_dilate=11` is just enough to sever it (half the bridge width is 10m), which
produces a `MultiPolygon` and triggers the crash.

```python
import shapely.geometry
from ftw_tools.postprocess.polygonize import polygonize
import numpy as np
import rasterio
import geopandas as gpd
import matplotlib.pyplot as plt
from rasterio.transform import from_bounds

# Minimal reproducer for the close_interiors + erode_dilate crash.
# The idea: two blobs joined by a thin bridge. When we erode enough to snap
# the bridge, the polygon splits into a MultiPolygon. close_interiors then
# tries to call .exterior on it, which doesn't exist → AttributeError.
mask = np.zeros((50, 50), dtype=np.uint8)
mask[10:20, 5:15] = 1   # left blob
mask[10:20, 17:27] = 1  # right blob
mask[14:16, 15:17] = 1  # 2-pixel (20m) bridge — this is what gets snapped

# UTM so distances are in metres (pixel size = 10m here)
with rasterio.open(
    '/tmp/test_input.tif', 'w',
    driver='GTiff', height=50, width=50, count=1,
    dtype='uint8', crs='EPSG:32632',
    transform=from_bounds(0, 0, 500, 500, 50, 50)
) as dst:
    dst.write(mask, 1)

# erode_dilate=11 is just enough to cut through the 20m bridge (needs > 10m).
# After the erosion step the single shape becomes two → MultiPolygon.
# This is where the crash happens when close_interiors=True.
polygonize(
    input='/tmp/test_input.tif',
    out='/tmp/test_out.parquet',
    erode_dilate=11,       # snaps the bridge → MultiPolygon
    close_interiors=True,  # bombs here: MultiPolygon has no .exterior
    overwrite=True,
)

# Show the input mask alongside what polygonize produced (or crashed trying to).
parq = gpd.read_parquet('/tmp/test_out.parquet')
fig, axes = plt.subplots(1, 2, figsize=(10, 5))

axes[0].imshow(mask, cmap='Greens', interpolation='nearest')
axes[0].set_title('Input raster mask\n(2 blobs + 2px bridge)')
axes[0].axis('off')

parq.plot(ax=axes[1], color='#f4a261', edgecolor='black', linewidth=0.8)
axes[1].set_title(f'Polygonized output\nerode_dilate=11, close_interiors=True  (n={len(parq)})')
axes[1].axis('off')

# The two panels use different coordinate systems, so we pin the extents manually.
with rasterio.open('/tmp/test_input.tif') as src:
    b = src.bounds

axes[0].set_xlim(0, mask.shape[1])
axes[0].set_ylim(mask.shape[0], 0)  # flip so origin is top-left
axes[1].set_xlim(b.left, b.right)
axes[1].set_ylim(b.bottom, b.top)
axes[1].set_aspect('equal')

plt.suptitle('Reproducer: erode_dilate + close_interiors → MultiPolygon crash', fontweight='bold')
plt.tight_layout()
plt.show()
```
<img width="922" height="495" alt="image" src="https://github.com/user-attachments/assets/8164e711-c022-4f8f-a49a-83bc76675398" />

