### PR TITLE
fix: add nan to num conversion before inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ Options:
   -mps, --mps_mode                Run inference in MPS mode (Apple GPUs).
   --save_scores                   Save segmentation softmax scores (rescaled to [0,255])
                                   instead of classes (argmax of scores)
+  --compute_consensus             Compute corner consensus scores during inference
+  --nan_fill_value FLOAT          Value used to replace NaN/nodata pixels before
+                                  inference.  [default: 0.0]
   --help                          Show this message and exit.
 ```
 
@@ -638,6 +641,8 @@ Options:
   -cot, --overlap_contain_threshold FLOAT RANGE
                                   Overlap containment threshold for merging
                                   polygons.  [default: 0.8; 0.0<=x<=1.0]
+  --nan_fill_value FLOAT          Value used to replace NaN/nodata pixels before
+                                  inference.  [default: 0.0]
   --help                          Show this message and exit.
 ```
 

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -877,6 +877,13 @@ def inference_download(
     show_default=True,
     help="Compute corner consensus scores during inference",
 )
+@click.option(
+    "--nan_fill_value",
+    type=float,
+    default=0.0,
+    show_default=True,
+    help="Value used to replace NaN/nodata pixels before inference.",
+)
 def inference_run(
     input: str,
     model: str,
@@ -891,6 +898,7 @@ def inference_run(
     mps_mode: bool,
     save_scores: bool,
     compute_consensus: bool,
+    nan_fill_value: float,
 ):
     from ftw_tools.inference.inference import run
 
@@ -908,6 +916,7 @@ def inference_run(
         mps_mode,
         save_scores,
         compute_consensus,
+        nan_fill_value,
     )
 
 
@@ -1061,6 +1070,13 @@ def inference_run(
     show_default=True,
     help="Overlap containment threshold for merging polygons.",
 )
+@click.option(
+    "--nan_fill_value",
+    type=float,
+    default=0.0,
+    show_default=True,
+    help="Value used to replace NaN/nodata pixels before inference.",
+)
 def inference_run_instance_segmentation(
     input,
     model,
@@ -1082,6 +1098,7 @@ def inference_run_instance_segmentation(
     close_interiors,
     overlap_iou_threshold,
     overlap_contain_threshold,
+    nan_fill_value,
 ):
     from ftw_tools.inference.inference import run_instance_segmentation
 
@@ -1106,6 +1123,7 @@ def inference_run_instance_segmentation(
         close_interiors=close_interiors,
         overlap_iou_threshold=overlap_iou_threshold,
         overlap_contain_threshold=overlap_contain_threshold,
+        nan_fill_value=nan_fill_value,
     )
 
 

--- a/ftw_tools/inference/inference.py
+++ b/ftw_tools/inference/inference.py
@@ -12,10 +12,8 @@ import rasterio
 import shapely.geometry
 import torch
 import torch.nn.functional as F
-import torchgeo
 from einops import rearrange
 from kornia.constants import Resample
-from packaging.version import Version, parse
 from rasterio.enums import ColorInterp
 from rasterio.transform import from_bounds
 from torch.utils.data import DataLoader
@@ -112,21 +110,44 @@ def setup_inference(input, out, gpu, patch_size, padding, overwrite, mps_mode):
 
 
 def run(
-    input,
-    model,
-    out,
-    resize_factor,
-    gpu,
-    patch_size,
-    batch_size,
-    num_workers,
-    padding,
-    overwrite,
-    mps_mode,
-    save_scores,
+    input: str,
+    model: str,
+    out: str | None,
+    resize_factor: int,
+    gpu: int,
+    patch_size: int | None,
+    batch_size: int,
+    num_workers: int,
+    padding: int | None,
+    overwrite: bool,
+    mps_mode: bool,
+    save_scores: bool,
     compute_consensus: bool = False,
+    nan_fill_value: float = 0.0,
     preprocess_fn: Callable = default_preprocess,
-):
+) -> None:
+    """Run semantic segmentation inference on a raster image.
+
+    Args:
+        input: Path to the input .tif or .vrt file.
+        model: Model name from the registry or path to a .ckpt file.
+        out: Output GeoTIFF path. Defaults to ``inference.<input>``.
+        resize_factor: Upsampling factor applied before the model.
+        gpu: GPU index to use; -1 for CPU.
+        patch_size: Patch size in pixels. Auto-selected if None.
+        batch_size: Number of patches per batch.
+        num_workers: DataLoader worker count.
+        padding: Pixels to discard from each patch edge. Auto-selected if None.
+        overwrite: Overwrite output if it already exists.
+        mps_mode: Use Apple MPS backend.
+        save_scores: Save per-class softmax scores instead of argmax labels.
+        compute_consensus: Track overlap disagreements across patches.
+        nan_fill_value: Replacement value for NaN/nodata pixels. Defaults to 0.0.
+        preprocess_fn: Transform applied to each sample before inference.
+
+    Returns:
+        None
+    """
     if save_scores and compute_consensus:
         raise ValueError("save_scores and compute_consensus are mutually exclusive.")
 
@@ -206,6 +227,8 @@ def run(
 
     for batch in dl_enumerator:
         images = batch["image"]
+        # Replace NaN/nodata values with nan_fill_value to prevent invalid inputs from reaching the model
+        images = torch.nan_to_num(images, nan=nan_fill_value)
         images = up_sample(images)
 
         if model_type in ["fcsiamdiff", "fcsiamconc", "fcsiamavg"]:
@@ -433,6 +456,7 @@ def run_instance_segmentation(
     close_interiors: bool = True,
     overlap_iou_threshold: float = 0.3,
     overlap_contain_threshold: float = 0.8,
+    nan_fill_value: float = 0.0,
 ):
     """Run instance segmentation inference on an image.
 
@@ -501,7 +525,10 @@ def run_instance_segmentation(
     # Run inference
     polygons = []
     for batch in tqdm(dataloader, total=len(dataloader)):
-        images = batch["image"].to(device)
+        images = batch["image"]
+        # Replace NaN/nodata values with nan_fill_value to prevent invalid inputs from reaching the model
+        images = torch.nan_to_num(images, nan=nan_fill_value)
+        images = images.to(device)
         predictions = model(images)
 
         crs = dataset.crs


### PR DESCRIPTION
## Description

Images with nodata/NaN pixels were causing the model to predict the entire affected patch as background (class 0). The root cause is NaN values surviving into the preprocessing normalization and silently poisoning the whole patch output.

The fix is a single `torch.nan_to_num` call before each batch hits the model. The fill value defaults to `0.0` but can be changed via the new `--nan_fill_value` CLI option on both `ftw inference run` and `ftw inference run-instance-segmentation`, useful for testing different replacement strategies.

Also removed two unused imports from `inference.py`: `torchgeo` and `from packaging.version import Version, parse`.

### Evidence

Screenshots attached using PRUE EfficientNet-B3 CCBY:

- **Before:** patches touching nodata areas come out entirely as background, even where there are clearly visible fields.
- **After:** same patches are correctly predicted. In QGIS the nodata pixels just show as transparent (you can see the Google Maps basemap through them), confirming exactly where they are.

<div align="center">

| Before | After |
|:------:|:-----:|
| <img width="370" alt="Before" src="https://github.com/user-attachments/assets/8ac11f3a-b32e-4db7-9fdb-6c640729f8e8" /> | <img width="370" alt="After" src="https://github.com/user-attachments/assets/b212a99c-0923-40e6-b35d-9b1f7eea9459" /> |

</div>