### PR TITLE
Feat/del anything v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ Options:
                                   mspc]
   -m, --model [DelineateAnything|DelineateAnything-S|DelineateAnythingV2]
                                   The model to use for inference.  [default:
-                                  DelineateAnything]
+                                  DelineateAnythingV2]
   --gpu INTEGER RANGE             GPU ID to use. If not provided, CPU will be
                                   used by default.  [x>=0]
   -r, --resize_factor INTEGER RANGE

--- a/README.md
+++ b/README.md
@@ -513,12 +513,21 @@ And that's it! In 4 lines of code, you obtained an FTW model, downloaded S2 data
 
 #### 1. End-to-end inference (using `ftw inference instance-segmentation-all`)
 
-[Delineate Anything](https://lavreniuk.github.io/Delineate-Anything/) is a pretrained instance segmentation which can detect and segment out individual field boundaries directly to polygons without an intermediate predictions raster. It's trained on the [FBIS-22M](https://huggingface.co/datasets/MykolaL/FBIS-22M) which is a large-scale, multi-resolution dataset comprising 672,909 high-resolution satellite image patches (0.25 m – 10 m) and 22,926,427 instance masks of individual fields. The model comes in two variants: `DelineateAnything` and `DelineateAnything-S`. `DelineateAnything` is the full model and `DelineateAnything-S` is a smaller model that is faster to run (see table below for details). If you use this model in your research, please cite the [Delineate Anything paper](https://arxiv.org/abs/2504.02534).
+[Delineate Anything](https://lavreniuk.github.io/Delineate-Anything/) is a pretrained instance segmentation which can detect and segment out individual field boundaries directly to polygons without an intermediate predictions raster. It's trained on the [FBIS-22M](https://huggingface.co/datasets/MykolaL/FBIS-22M) which is a large-scale, multi-resolution dataset comprising 672,909 high-resolution satellite image patches (0.25 m – 10 m) and 22,926,427 instance masks of individual fields. The model comes in three variants: `DelineateAnything`, `DelineateAnything-S`, and `DelineateAnythingV2`. `DelineateAnything` is the full v1 model and `DelineateAnything-S` is a smaller v1 model that is faster to run (see table below for details). `DelineateAnythingV2` is a newer, improved version of the model published by the same authors on [Hugging Face](https://huggingface.co/MykolaL/DelineateAnything). If you use this model in your research, please cite the [Delineate Anything paper](https://arxiv.org/abs/2504.02534).
 
 | Method                   | mAP@0.5 | mAP@0.5:0.95 | Latency (ms) | Size    |
 | ------------------------ | ------- | ------------ | ------------ | ------- |
 | **Delineate Anything-S** | 0.632   | 0.383        | 16.8         | 17.6 MB |
 | **Delineate Anything**   | 0.720   | 0.477        | 25.0         | 125 MB  |
+
+Additional evaluation comparing `DelineateAnything` (v1) and `DelineateAnythingV2`:
+
+**Table 1: Quantitative performance on the independent 100-country benchmark.** (from [arXiv:2607.19069](https://arxiv.org/abs/2607.19069))
+
+| Method       | mAP@0.5 | mAP@0.5:0.95 | Precision | Recall |
+| ------------ | ------- | ------------ | --------- | ------ |
+| **DelAny**   | 0.275   | 0.103        | 0.345     | 0.454  |
+| **DelAny v2**| 0.559   | 0.278        | 0.639     | 0.525  |
 
 You can run Delineate Anything on a single scene using the `ftw inference instance-segmentation-all` command or optionally on an existing local file using `ftw inference run-instance-segmentation`. See below for examples.
 
@@ -565,7 +574,7 @@ Options:
                                   = Microsoft Planetary Computer, earthsearch
                                   = EarthSearch (Element84/AWS).  [default:
                                   mspc]
-  -m, --model [DelineateAnything|DelineateAnything-S]
+  -m, --model [DelineateAnything|DelineateAnything-S|DelineateAnythingV2]
                                   The model to use for inference.  [default:
                                   DelineateAnything]
   --gpu INTEGER RANGE             GPU ID to use. If not provided, CPU will be

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -928,7 +928,9 @@ def inference_run(
 @click.option(
     "--model",
     "-m",
-    type=click.Choice(["DelineateAnything", "DelineateAnything-S"]),
+    type=click.Choice(
+        ["DelineateAnything", "DelineateAnything-S", "DelineateAnythingV2"]
+    ),
     default="DelineateAnything",
     show_default=True,
     help="The model to use for inference.",
@@ -1157,7 +1159,9 @@ def inference_run_instance_segmentation(
 @click.option(
     "--model",
     "-m",
-    type=click.Choice(["DelineateAnything", "DelineateAnything-S"]),
+    type=click.Choice(
+        ["DelineateAnything", "DelineateAnything-S", "DelineateAnythingV2"]
+    ),
     default="DelineateAnything",
     show_default=True,
     help="The model to use for inference.",

--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -931,7 +931,7 @@ def inference_run(
     type=click.Choice(
         ["DelineateAnything", "DelineateAnything-S", "DelineateAnythingV2"]
     ),
-    default="DelineateAnything",
+    default="DelineateAnythingV2",
     show_default=True,
     help="The model to use for inference.",
 )

--- a/ftw_tools/inference/inference.py
+++ b/ftw_tools/inference/inference.py
@@ -437,7 +437,7 @@ def run(
 @torch.inference_mode()
 def run_instance_segmentation(
     input: str,
-    model: Literal["DelineateAnything-S", "DelineateAnything"],
+    model: Literal["DelineateAnything-S", "DelineateAnything", "DelineateAnythingV2"],
     out: str,
     gpu: int | None = None,
     num_workers: int = 4,
@@ -483,15 +483,19 @@ def run_instance_segmentation(
         overlap_contain_threshold: Merge polygons with contain greater than this threshold.
 
     Raises:
-        AssertionError: If the model is not DelineateAnything or DelineateAnything-S.
+        AssertionError: If the model is not DelineateAnything, DelineateAnything-S, or DelineateAnythingV2.
 
     Returns:
         None
     """
     from ftw_tools.inference.models import DelineateAnything
 
-    assert model in ["DelineateAnything", "DelineateAnything-S"], (
-        "Model must be either DelineateAnything or DelineateAnything-S."
+    assert model in [
+        "DelineateAnything",
+        "DelineateAnything-S",
+        "DelineateAnythingV2",
+    ], (
+        "Model must be one of DelineateAnything, DelineateAnything-S, or DelineateAnythingV2."
     )
 
     padding = padding if padding is not None else patch_size // 4

--- a/ftw_tools/inference/model_registry.py
+++ b/ftw_tools/inference/model_registry.py
@@ -117,6 +117,16 @@ MODEL_REGISTRY = {
         requires_polygonize=False,
         instance_segmentation=True,
     ),
+    "DelineateAnythingV2": ModelSpec(
+        title="DelineateAnything v2: Standard",
+        url="https://hf.co/MykolaL/DelineateAnything/resolve/main/DelineateAnythingv2.pt",
+        description="An improved single-shot model trained on Field Boundary Instance Segmentation - 22M dataset (FBIS-22M), based on a YOLOv11 backbone. This is the second version of the DelineateAnything model, offering better accuracy than v1. Requires a single time window - automatic selection will get one at the beginning of the grow season, but other times can be tried.",
+        license="AGPL-3",
+        version="v2",
+        requires_window=False,
+        requires_polygonize=False,
+        instance_segmentation=True,
+    ),
     "FTW_PRUE_EFNET_B3": ModelSpec(
         title="FTW v3: Standard, B3",
         url=f"{RELEASE_URL}v3/prue_efnet3_checkpoint.ckpt",

--- a/ftw_tools/inference/models.py
+++ b/ftw_tools/inference/models.py
@@ -113,14 +113,14 @@ class DelineateAnything:
     checkpoints = {
         "DelineateAnything-S": "https://hf.co/torchgeo/delineate-anything-s/resolve/69cd440b0c5bd450ced145e68294aa9393ddae05/delineate_anything_s_rgb_yolo11n-b879d643.pt",
         "DelineateAnything": "https://hf.co/torchgeo/delineate-anything/resolve/60bea7b2f81568d16d5c75e4b5b06289e1d7efaf/delineate_anything_rgb_yolo11x-88ede029.pt",
-        "DelineateAnythingV2": "https://hf.co/MykolaL/DelineateAnything/resolve/main/DelineateAnythingv2.pt",
+        "DelineateAnythingV2": "https://hf.co/MykolaL/DelineateAnything/resolve/369d0b4c44cf9bec2bd3a27bc81810cadd2c963e/DelineateAnythingv2.pt",
     }
 
     def __init__(
         self,
         model: Literal[
             "DelineateAnything-S", "DelineateAnything", "DelineateAnythingV2"
-        ] = "DelineateAnything-S",
+        ] = "DelineateAnythingV2",
         patch_size: tuple[int, int] | int = 256,
         resize_factor: int = 2,
         max_detections: int = 100,

--- a/ftw_tools/inference/models.py
+++ b/ftw_tools/inference/models.py
@@ -113,12 +113,13 @@ class DelineateAnything:
     checkpoints = {
         "DelineateAnything-S": "https://hf.co/torchgeo/delineate-anything-s/resolve/69cd440b0c5bd450ced145e68294aa9393ddae05/delineate_anything_s_rgb_yolo11n-b879d643.pt",
         "DelineateAnything": "https://hf.co/torchgeo/delineate-anything/resolve/60bea7b2f81568d16d5c75e4b5b06289e1d7efaf/delineate_anything_rgb_yolo11x-88ede029.pt",
+        "DelineateAnythingV2": "https://hf.co/MykolaL/DelineateAnything/resolve/main/DelineateAnythingv2.pt",
     }
 
     def __init__(
         self,
         model: Literal[
-            "DelineateAnything-S", "DelineateAnything"
+            "DelineateAnything-S", "DelineateAnything", "DelineateAnythingV2"
         ] = "DelineateAnything-S",
         patch_size: tuple[int, int] | int = 256,
         resize_factor: int = 2,
@@ -130,7 +131,7 @@ class DelineateAnything:
         """Initialize the DelineateAnything model.
 
         Args:
-            model: The model variant to use, either "DelineateAnything-S" or "DelineateAnything".
+            model: The model variant to use, one of "DelineateAnything-S", "DelineateAnything", or "DelineateAnythingV2".
             patch_size: The size of the input images. If an int is provided, it will be used for both width and height.
             resize_factor: The factor to resize the input images by.
             max_detections: Maximum number of detections per image.


### PR DESCRIPTION
Adds support for `DelineateAnythingV2`, a newer instance segmentation model from the same DelAny authors.

**Changes:**
- Registered `DelineateAnythingV2` in model_registry.py and the `DelineateAnything` model wrapper (models.py)
- Added `DelineateAnythingV2` as a valid `--model` choice for `run-instance-segmentation` and `instance-segmentation-all` CLI commands
- Updated README with usage example and benchmark comparison (Table 1 from [arXiv:2607.19069](https://arxiv.org/abs/2607.19069))

**Note:** The existing `DelineateAnything`/`DelineateAnything-S` checkpoints are pulled from the `torchgeo` HF collection, while `DelineateAnythingV2` is pulled directly from the [DelAny author's HF page](https://huggingface.co/MykolaL/DelineateAnything) since it isn't mirrored in `torchgeo` yet. Worth keeping an eye on in case the source/URL changes upstream.

Verified end-to-end with `run-instance-segmentation` against a local test raster. 