### PR TITLE
feat: add Fields of the Planet models

### DIFF
--- a/ftw_tools/inference/model_registry.py
+++ b/ftw_tools/inference/model_registry.py
@@ -19,7 +19,7 @@ class ModelSpec(BaseModel):
     url: str
     title: str
     description: str = Field(min_length=1)
-    license: Literal["CC-BY-4.0", "AGPL-3", "Mixed Open Licenses"]
+    license: Literal["CC-BY-4.0", "CC-BY-NC-4.0", "AGPL-3", "Mixed Open Licenses"]
     version: str = Field(description="Model version (e.g., v1, v2, v3)")
     requires_window: bool = True
     requires_polygonize: bool = True
@@ -138,6 +138,20 @@ MODEL_REGISTRY = {
         description="A three class (field, boundary, neither) model trained with EfficientNet-B7 on a variety of open data licenses (including CC-BY-NC-SA and non-CC open data licenses), that is the part of the FTW Baseline v3 release. It along with the other two EfficientNet models will likely perform best. B7 is likely the most accurate of FTW v3, but the slowest. Requires two time windows, at the start and end of the growing season.",
         license="Mixed Open Licenses",
         version="v3",
+    ),
+    "FTP_PRUE_EFNET_B3": ModelSpec(
+        title="FTP: PRUE+, B3",
+        url="https://hf.co/taylor-geospatial/ftp-b3/resolve/main/ftp-b3.ckpt",
+        description="A three class (field, boundary, neither) Fields of the Planet model trained with EfficientNet-B3 on 3 m PlanetScope imagery. This is the headline PRUE+ model and is more compact than the B7 variant. Requires two seasonal time windows with four bands each.",
+        license="CC-BY-NC-4.0",
+        version="v1",
+    ),
+    "FTP_PRUE_EFNET_B7": ModelSpec(
+        title="FTP: PRUE+, B7",
+        url="https://hf.co/taylor-geospatial/ftp-b7/resolve/main/ftp-b7.ckpt",
+        description="A three class (field, boundary, neither) Fields of the Planet model trained with EfficientNet-B7 on 3 m PlanetScope imagery. This larger PRUE+ variant offers stronger pixel IoU at the cost of additional compute. Requires two seasonal time windows with four bands each.",
+        license="CC-BY-NC-4.0",
+        version="v1",
     ),
     "FTW_PRUE_EFNET_B3_CCBY": ModelSpec(
         title="FTW v3: CC-BY, B3",

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -72,3 +72,20 @@ def test_all_registry_values_are_model_specs():
 def test_model_names_are_unique():
     keys = list(MODEL_REGISTRY.keys())
     assert len(keys) == len(set(keys)), "Duplicate model names found"
+
+
+@pytest.mark.parametrize(
+    ("model_name", "backbone"),
+    [("FTP_PRUE_EFNET_B3", "b3"), ("FTP_PRUE_EFNET_B7", "b7")],
+)
+def test_ftp_models(model_name: str, backbone: str):
+    spec = MODEL_REGISTRY[model_name]
+
+    assert spec.url == (
+        f"https://hf.co/taylor-geospatial/ftp-{backbone}/resolve/main/"
+        f"ftp-{backbone}.ckpt"
+    )
+    assert spec.license == "CC-BY-NC-4.0"
+    assert spec.requires_window is True
+    assert spec.requires_polygonize is True
+    assert spec.instance_segmentation is False


### PR DESCRIPTION
## Summary

- register the Fields of the Planet PRUE+ EfficientNet-B3 and EfficientNet-B7 checkpoints
- expose the checkpoints with their CC-BY-NC-4.0 license and two-window semantic-segmentation metadata
- add regression coverage for both registry entries and their download URLs

## Validation

- `pre-commit run --files ftw_tools/inference/model_registry.py tests/test_model_registry.py`
- targeted Pydantic registry validation for both FTP entries
- `python3 -m py_compile ftw_tools/inference/model_registry.py tests/test_model_registry.py`
- verified both Hugging Face checkpoint URLs return HTTP 200

I did not run the full test suite locally because it requires installing the complete geospatial and ML dependency stack; the targeted checks above cover the changed registry path, and the full suite is left to CI.

Fixes #264
