### PR TITLE
Fix FTW dataset mask selection when building sample list

### DIFF
--- a/ftw_tools/training/datasets.py
+++ b/ftw_tools/training/datasets.py
@@ -169,12 +169,11 @@ class FTW(NonGeoDataset):
                     os.path.join(country_root, "label_masks/edges", f"{idx}.tif")
                 )
 
-                # Skip the image AOI's which does not have all four corresponding files
+                mask_fn = masks_3c_fn if self.load_boundaries else masks_2c_fn
+
+                # Skip AOIs missing either image or the selected mask type.
                 if not (
-                    window_b_fn.exists()
-                    and window_a_fn.exists()
-                    and masks_2c_fn.exists()
-                    and masks_3c_fn.exists()
+                    window_b_fn.exists() and window_a_fn.exists() and mask_fn.exists()
                 ):
                     continue
 
@@ -182,11 +181,6 @@ class FTW(NonGeoDataset):
                     raise ValueError(
                         "ERROR: Missing edge files! Run ./scripts/add_edges_to_dataset.py"
                     )
-
-                if self.load_boundaries:
-                    mask_fn = masks_3c_fn
-                else:
-                    mask_fn = masks_2c_fn
 
                 file_record = {
                     "window_b": str(window_b_fn),

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import geopandas as gpd
 import pytest
 from shapely.geometry import Point
@@ -52,7 +54,10 @@ def test_ftw_requires_only_selected_mask_type(tmp_path, load_boundaries, mask_di
         verbose=False,
     )
     assert len(dataset) == 1
-    assert dataset.filenames[0]["mask"].endswith(f"{mask_dirname}/{aoi_id}.tif")
+    assert Path(dataset.filenames[0]["mask"]).parts[-2:] == (
+        mask_dirname,
+        f"{aoi_id}.tif",
+    )
 
 
 def test_ftw_skips_sample_missing_selected_mask_type(tmp_path):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,84 @@
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from ftw_tools.training.datasets import FTW
+
+
+def _make_country_dir(root, country, aoi_id="sample_0", mask_dirnames=()):
+    """Build a minimal fake FTW dataset directory for a single country/sample.
+
+    Creates the window_a/window_b image files (always) plus the
+    ``label_masks/<name>`` mask file for each name in ``mask_dirnames``. The
+    corresponding mask directories are always created (even if empty) so that
+    ``_check_integrity`` passes regardless of which mask type is requested.
+    """
+    country_dir = root / country
+    (country_dir / "s2_images" / "window_a").mkdir(parents=True)
+    (country_dir / "s2_images" / "window_b").mkdir(parents=True)
+    (country_dir / "label_masks" / "semantic_2class").mkdir(parents=True)
+    (country_dir / "label_masks" / "semantic_3class").mkdir(parents=True)
+
+    (country_dir / "s2_images" / "window_a" / f"{aoi_id}.tif").touch()
+    (country_dir / "s2_images" / "window_b" / f"{aoi_id}.tif").touch()
+    for name in mask_dirnames:
+        (country_dir / "label_masks" / name / f"{aoi_id}.tif").touch()
+
+    chips = gpd.GeoDataFrame(
+        {"aoi_id": [aoi_id], "split": ["train"]},
+        geometry=[Point(0, 0)],
+        crs="EPSG:4326",
+    )
+    chips.to_parquet(country_dir / f"chips_{country}.parquet")
+
+    return country_dir
+
+
+@pytest.mark.parametrize(
+    ("load_boundaries", "mask_dirname"),
+    [(False, "semantic_2class"), (True, "semantic_3class")],
+)
+def test_ftw_requires_only_selected_mask_type(tmp_path, load_boundaries, mask_dirname):
+    """A sample with only its requested mask type present should be included."""
+    country = "france"
+    aoi_id = "sample_0"
+    _make_country_dir(tmp_path, country, aoi_id, mask_dirnames=(mask_dirname,))
+
+    dataset = FTW(
+        root=str(tmp_path),
+        countries=country,
+        split="train",
+        load_boundaries=load_boundaries,
+        verbose=False,
+    )
+    assert len(dataset) == 1
+    assert dataset.filenames[0]["mask"].endswith(f"{mask_dirname}/{aoi_id}.tif")
+
+
+def test_ftw_skips_sample_missing_selected_mask_type(tmp_path):
+    """Only the 2-class mask exists for the sample. Requesting the 2-class mask
+    (load_boundaries=False) should find it, while requesting the 3-class mask
+    (load_boundaries=True) should skip the sample -- demonstrating that only the
+    selected mask type is required, not both.
+    """
+    country = "france"
+    aoi_id = "sample_0"
+    _make_country_dir(tmp_path, country, aoi_id, mask_dirnames=("semantic_2class",))
+
+    dataset_2class = FTW(
+        root=str(tmp_path),
+        countries=country,
+        split="train",
+        load_boundaries=False,
+        verbose=False,
+    )
+    assert len(dataset_2class) == 1
+
+    dataset_3class = FTW(
+        root=str(tmp_path),
+        countries=country,
+        split="train",
+        load_boundaries=True,
+        verbose=False,
+    )
+    assert len(dataset_3class) == 0


### PR DESCRIPTION
# Summary

Fixes `FTW` silently excluding valid AOIs when the unselected semantic mask type is absent.

The dataset previously required both the 2-class and 3-class mask files for every AOI, despite loading only one based on `load_boundaries`. This conflicted with `_check_integrity()`, which validates only the selected mask directory.

The sample-discovery logic now:

1. selects `mask_fn` from `load_boundaries`;
2. requires the two temporal image files and only `mask_fn`.

# Tests

Added regression coverage for both mask modes:

- an AOI with only the requested mask type is included;
- an AOI is skipped only if the requested mask type is missing.

Validated with:

```text
.venv/bin/python -m pytest tests/test_datasets.py -v
```

Result: `3 passed`.