### PR TITLE
Fix geographic polygonization units

### DIFF
--- a/ftw_tools/cli.py
+++ b/ftw_tools/cli.py
@@ -1031,7 +1031,7 @@ def inference_run(
     type=click.FloatRange(min=0.0),
     default=2,
     show_default=True,
-    help="Simplification factor to use when polygonizing in the unit of the CRS, e.g. meters for Sentinel-2 imagery in UTM. Set to 0 to disable simplification.",
+    help="Simplification distance in metres. Set to 0 to disable simplification.",
 )
 @click.option(
     "--min_size",
@@ -1254,7 +1254,7 @@ def inference_run_instance_segmentation(
     type=click.FloatRange(min=0.0),
     default=2,
     show_default=True,
-    help="Simplification factor to use when polygonizing in the unit of the CRS, e.g. meters for Sentinel-2 imagery in UTM. Set to 0 to disable simplification.",
+    help="Simplification distance in metres. Set to 0 to disable simplification.",
 )
 @click.option(
     "--min_size",
@@ -1385,7 +1385,7 @@ def inference_run_instance_segmentation_all(
     type=click.FloatRange(min=0.0),
     default=15,
     show_default=True,
-    help="Simplification factor to use when polygonizing in the unit of the CRS, e.g. meters for Sentinel-2 imagery in UTM. Set to 0 to disable simplification.",
+    help="Simplification distance in metres for geographic rasters, or in CRS units for projected rasters. Set to 0 to disable simplification.",
 )
 @click.option(
     "--min_size",
@@ -1447,7 +1447,7 @@ def inference_run_instance_segmentation_all(
     type=click.FloatRange(min=0.0),
     default=0,
     show_default=True,
-    help="Distance (in CRS units, e.g., meters) for a morphological opening (erode then dilate) applied to each polygon to shave spurs and remove thin slivers. Set 0 to disable. A good starting value is 0.5–1x the raster pixel size.",
+    help="Distance in metres for geographic rasters, or in CRS units for projected rasters, for a morphological opening (erode then dilate) applied to each polygon to shave spurs and remove thin slivers. Set 0 to disable. A good starting value is 0.5–1x the raster pixel size.",
 )
 @click.option(
     "--dilate_erode",
@@ -1455,7 +1455,7 @@ def inference_run_instance_segmentation_all(
     type=click.FloatRange(min=0.0),
     default=0,
     show_default=True,
-    help="Distance (in CRS units, e.g., meters) for a morphological closing (dilate then erode) applied to each polygon to seal hairline gaps, fill pinholes, and connect near-touching parts without net growth. Set 0 to disable. A good starting value is 0.5–1x the raster pixel size.",
+    help="Distance in metres for geographic rasters, or in CRS units for projected rasters, for a morphological closing (dilate then erode) applied to each polygon to seal hairline gaps, fill pinholes, and connect near-touching parts without net growth. Set 0 to disable. A good starting value is 0.5–1x the raster pixel size.",
 )
 @click.option(
     "--erode_dilate_raster",

--- a/ftw_tools/inference/utils.py
+++ b/ftw_tools/inference/utils.py
@@ -4,8 +4,28 @@ import geopandas as gpd
 import numpy as np
 import shapely
 from fiboa_cli.registry import Registry
+from pyproj import CRS
 from vecorel_cli.encoding.geoparquet import GeoParquet
 from vecorel_cli.vecorel.collection import Collection
+
+
+def metric_crs_for_geographic_bounds(crs, bounds) -> CRS:
+    """Choose a local metre-based CRS for a geographic footprint."""
+    footprint = gpd.GeoSeries([shapely.geometry.box(*bounds)], crs=crs)
+    footprint_wgs84 = footprint.to_crs(CRS.from_epsg(4326))
+    latitude = float(footprint_wgs84.union_all().centroid.y)
+
+    # UTM stops at 84 N / 80 S. Use the matching Universal Polar
+    # Stereographic CRS for inputs beyond those limits.
+    if latitude >= 84:
+        return CRS.from_epsg(32661)
+    if latitude <= -80:
+        return CRS.from_epsg(32761)
+
+    estimated = footprint.estimate_utm_crs()
+    if estimated is None:
+        raise ValueError("Unable to determine a metric CRS for the input bounds.")
+    return CRS.from_user_input(estimated)
 
 
 def _to_polygons_only(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -122,9 +142,17 @@ def postprocess_instance_polygons(
     Returns:
         The postprocessed polygons.
     """
-    # Convert polygons to a meter based CRS
+    # Use a local metre-based CRS for geographic inputs. Keep the existing
+    # EPSG:6933 path for projected inputs so their behaviour remains unchanged.
     src_crs = polygons.crs
-    polygons.to_crs("EPSG:6933", inplace=True)
+    parsed_crs = CRS.from_user_input(src_crs)
+    if parsed_crs.is_geographic and not polygons.empty:
+        working_crs = metric_crs_for_geographic_bounds(
+            parsed_crs, polygons.total_bounds
+        )
+    else:
+        working_crs = CRS.from_epsg(6933)
+    polygons.to_crs(working_crs, inplace=True)
 
     if close_interiors:
         polygons.geometry = polygons.geometry.exterior

--- a/ftw_tools/postprocess/polygonize.py
+++ b/ftw_tools/postprocess/polygonize.py
@@ -15,7 +15,11 @@ from shapely.ops import transform, unary_union
 from skimage.morphology import dilation, erosion
 from tqdm import tqdm
 
-from ftw_tools.inference.utils import convert_to_fiboa, features_to_dataframe
+from ftw_tools.inference.utils import (
+    convert_to_fiboa,
+    features_to_dataframe,
+    metric_crs_for_geographic_bounds,
+)
 from ftw_tools.settings import SUPPORTED_POLY_FORMATS_TXT
 
 
@@ -344,6 +348,8 @@ def polygonize(
     # read the input file as a mask
     with rasterio.open(input) as src:
         original_crs = src.crs.to_string()
+        source_crs = CRS.from_user_input(src.crs)
+        is_geographic = source_crs.is_geographic
         is_meters = src.crs.linear_units in ["m", "metre", "meter"]
         equal_area_crs = CRS.from_epsg(
             6933
@@ -355,6 +361,14 @@ def polygonize(
         equal_area_from_4326 = Transformer.from_crs(
             CRS.from_epsg(4326), equal_area_crs, always_xy=True
         ).transform
+        if is_geographic:
+            metric_crs = metric_crs_for_geographic_bounds(source_crs, src.bounds)
+            to_metric = Transformer.from_crs(
+                source_crs, metric_crs, always_xy=True
+            ).transform
+            from_metric = Transformer.from_crs(
+                metric_crs, source_crs, always_xy=True
+            ).transform
         tags = src.tags()
 
         input_height, input_width = src.shape
@@ -427,6 +441,12 @@ def polygonize(
 
                         geom = shapely.geometry.shape(geom_geojson)
 
+                        # Distance- and area-based operations use metres for a
+                        # geographic raster. Projected rasters intentionally
+                        # retain their existing input-CRS behaviour.
+                        if is_geographic:
+                            geom = transform(to_metric, geom)
+
                         if erode_dilate > 0:
                             # morphological opening
                             geom = geom.buffer(
@@ -458,8 +478,12 @@ def polygonize(
                         if simplify > 0:
                             geom = geom.simplify(simplify)
 
-                        # Calculate the area of the reprojected geometry
-                        if is_meters:
+                        # Restore the input CRS before writing while retaining
+                        # the metric geometry for filtering and measurements.
+                        if is_geographic:
+                            geom_proj_meters = geom
+                            geom = transform(from_metric, geom)
+                        elif is_meters:
                             geom_proj_meters = geom
                         else:
                             # Reproject the geometry to the equal-area projection
@@ -481,7 +505,20 @@ def polygonize(
                         # explode MultiPolygons if needed
                         if isinstance(geom, shapely.geometry.MultiPolygon):
                             for g in geom.geoms:
-                                if is_meters:
+                                if is_geographic:
+                                    # GeoJSON rows are already in EPSG:4326;
+                                    # other rows remain in the source CRS.
+                                    proj_fn = (
+                                        Transformer.from_crs(
+                                            CRS.from_epsg(4326),
+                                            metric_crs,
+                                            always_xy=True,
+                                        ).transform
+                                        if is_geojson
+                                        else to_metric
+                                    )
+                                    g_proj = transform(proj_fn, g)
+                                elif is_meters:
                                     g_proj = g
                                 else:
                                     # If is_geojson, g has been reprojected to
@@ -520,7 +557,19 @@ def polygonize(
 
     # Merge adjacent polygons
     if merge_adjacent is not None:
-        if is_meters:
+        if is_geographic:
+            merge_proj_fn = (
+                Transformer.from_crs(
+                    CRS.from_epsg(4326), metric_crs, always_xy=True
+                ).transform
+                if is_geojson
+                else to_metric
+            )
+
+            def reproject_fn(geom):
+                return transform(merge_proj_fn, geom)
+
+        elif is_meters:
             reproject_fn = None
         else:
             # Geometries stored in `rows` may already have been reprojected to EPSG:4326

--- a/tests/test_polygonize_crs.py
+++ b/tests/test_polygonize_crs.py
@@ -1,0 +1,123 @@
+import math
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import pytest
+import rasterio
+from pyproj import CRS, Transformer
+from rasterio.transform import from_origin
+from shapely.geometry import box
+
+from ftw_tools.inference.utils import (
+    metric_crs_for_geographic_bounds,
+    postprocess_instance_polygons,
+)
+from ftw_tools.postprocess.polygonize import polygonize
+
+
+def write_mask(path: Path, crs: CRS, transform) -> None:
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[1:4, 1:4] = 1  # 900 m² at the nominal 10 m resolution
+    mask[5:7, 5:7] = 1  # 400 m²: removed by min_size
+
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=mask.shape[1],
+        height=mask.shape[0],
+        count=1,
+        dtype=mask.dtype,
+        crs=crs,
+        transform=transform,
+    ) as dst:
+        dst.write(mask, 1)
+
+
+@pytest.mark.parametrize(
+    ("crs", "transform"),
+    [
+        (
+            CRS.from_epsg(4326),
+            from_origin(
+                15.0, 48.0, 10 / (111_320 * math.cos(math.radians(48))), 10 / 111_320
+            ),
+        ),
+        (
+            CRS.from_epsg(32633),
+            from_origin(
+                *Transformer.from_crs(4326, 32633, always_xy=True).transform(15, 48),
+                10,
+                10,
+            ),
+        ),
+    ],
+    ids=["geographic", "projected"],
+)
+def test_polygonize_uses_metre_scale_and_preserves_crs(
+    tmp_path: Path, crs: CRS, transform
+) -> None:
+    mask_path = tmp_path / "mask.tif"
+    output_path = tmp_path / "fields.gpkg"
+    write_mask(mask_path, crs, transform)
+
+    polygonize(
+        str(mask_path),
+        str(output_path),
+        simplify=2,
+        min_size=500,
+        erode_dilate=2,
+        polygonization_stride=8,
+    )
+
+    fields = gpd.read_file(output_path)
+    assert fields.crs == crs
+    assert len(fields) == 1
+    assert 700 < fields.iloc[0]["metrics:area"] < 1_000
+    assert fields.geometry.is_valid.all()
+
+
+@pytest.mark.parametrize(
+    ("bounds", "expected_epsg"),
+    [((-10, 84.5, 10, 85), 32661), ((-10, -85, 10, -84.5), 32761)],
+)
+def test_metric_crs_uses_polar_projection(bounds, expected_epsg) -> None:
+    assert metric_crs_for_geographic_bounds(4326, bounds).to_epsg() == expected_epsg
+
+
+def test_shared_postprocessing_uses_metric_distance_and_restores_crs() -> None:
+    polygons = gpd.GeoDataFrame(
+        geometry=[box(15, 48, 15.0004, 48.0004)], crs="EPSG:4326"
+    )
+
+    result = postprocess_instance_polygons(
+        polygons, simplify=2, min_size=500, close_interiors=False
+    )
+
+    assert result.crs == polygons.crs
+    assert len(result) == 1
+    assert result.iloc[0]["metrics:area"] > 500
+
+
+def test_geographic_geojson_merge_keeps_metric_measurements(tmp_path: Path) -> None:
+    mask_path = tmp_path / "mask.tif"
+    output_path = tmp_path / "fields.geojson"
+    transform = from_origin(
+        15.0, 48.0, 10 / (111_320 * math.cos(math.radians(48))), 10 / 111_320
+    )
+    write_mask(mask_path, CRS.from_epsg(4326), transform)
+
+    polygonize(
+        str(mask_path),
+        str(output_path),
+        simplify=0,
+        min_size=0,
+        merge_adjacent=0.5,
+        polygonization_stride=8,
+    )
+
+    fields = gpd.read_file(output_path)
+    assert fields.crs == CRS.from_epsg(4326)
+    assert len(fields) == 2
+    assert sorted(fields["metrics:area"]) == pytest.approx([400, 900], rel=0.02)


### PR DESCRIPTION
Fixes #271

## Summary
- select a local UTM working CRS for geographic inputs, with UPS at polar latitudes
- apply simplification, polygon morphology, and minimum-area filtering in metres, then restore the requested output CRS
- use the same metric selection in shared instance-polygon postprocessing while leaving the projected-input path unchanged
- clarify the CLI units for simplification and morphology

## Tests
- `python -m pytest -q -o addopts='' tests/test_polygonize_crs.py tests/test_merge_adjacent.py` (18 passed)
- `python -m ruff format --check ftw_tools/inference/utils.py ftw_tools/postprocess/polygonize.py ftw_tools/cli.py tests/test_polygonize_crs.py`
- `python -m ruff check --no-fix --select I ftw_tools/inference/utils.py ftw_tools/postprocess/polygonize.py ftw_tools/cli.py tests/test_polygonize_crs.py`

The new fixtures cover comparable geographic/projected rasters, metre-scale simplification and morphology, area filtering, output CRS preservation, GeoJSON merge measurements, and UTM/UPS selection. A projected-raster parity check also produced identical geometry and metrics before and after this change.